### PR TITLE
Fix unused variable warnings

### DIFF
--- a/include/boost/numeric/ublas/matrix.hpp
+++ b/include/boost/numeric/ublas/matrix.hpp
@@ -3210,7 +3210,7 @@ namespace boost { namespace numeric {
 
         // Resizing
         BOOST_UBLAS_INLINE
-        void resize (size_type size, bool preserve = true) {
+        void resize (size_type size, bool /*preserve*/ = true) {
             size1_ = size;
             size2_ = size;
         }
@@ -3597,7 +3597,7 @@ namespace boost { namespace numeric {
 
         // Resizing
         BOOST_UBLAS_INLINE
-        void resize (size_type size, bool preserve = true) {
+        void resize (size_type size, bool /*preserve*/ = true) {
             size1_ = size;
             size2_ = size;
             size_common_ = ((std::min)(size1_, size2_));
@@ -4692,7 +4692,7 @@ namespace boost { namespace numeric {
 
         // Element lookup
         BOOST_UBLAS_INLINE
-        const_iterator1 find1 (int rank, size_type i, size_type j) const {
+        const_iterator1 find1 (int /*rank*/, size_type i, size_type j) const {
 #ifdef BOOST_UBLAS_USE_INDEXED_ITERATOR
             return const_iterator1 (*this, i, j);
 #else
@@ -4700,7 +4700,7 @@ namespace boost { namespace numeric {
 #endif
         }
         BOOST_UBLAS_INLINE
-        iterator1 find1 (int rank, size_type i, size_type j) {
+        iterator1 find1 (int /*rank*/, size_type i, size_type j) {
 #ifdef BOOST_UBLAS_USE_INDEXED_ITERATOR
             return iterator1 (*this, i, j);
 #else
@@ -4708,7 +4708,7 @@ namespace boost { namespace numeric {
 #endif
         }
         BOOST_UBLAS_INLINE
-        const_iterator2 find2 (int rank, size_type i, size_type j) const {
+        const_iterator2 find2 (int /*rank*/, size_type i, size_type j) const {
 #ifdef BOOST_UBLAS_USE_INDEXED_ITERATOR
             return const_iterator2 (*this, i, j);
 #else
@@ -4716,7 +4716,7 @@ namespace boost { namespace numeric {
 #endif
         }
         BOOST_UBLAS_INLINE
-        iterator2 find2 (int rank, size_type i, size_type j) {
+        iterator2 find2 (int /*rank*/, size_type i, size_type j) {
 #ifdef BOOST_UBLAS_USE_INDEXED_ITERATOR
             return iterator2 (*this, i, j);
 #else

--- a/include/boost/numeric/ublas/storage.hpp
+++ b/include/boost/numeric/ublas/storage.hpp
@@ -273,7 +273,7 @@ namespace boost { namespace numeric { namespace ublas {
 
         // Serialization
         template<class Archive>
-        void serialize(Archive & ar, const unsigned int version)
+        void serialize(Archive & ar, const unsigned int /*version*/)
         { 
             serialization::collection_size_type s(size_);
             ar & serialization::make_nvp("size",s);
@@ -451,7 +451,7 @@ namespace boost { namespace numeric { namespace ublas {
         friend class boost::serialization::access;
 
         template<class Archive>
-        void serialize(Archive & ar, const unsigned int version)
+        void serialize(Archive & ar, const unsigned int /*version*/)
         {
             serialization::collection_size_type s(size_);
             ar & serialization::make_nvp("size", s);

--- a/include/boost/numeric/ublas/vector.hpp
+++ b/include/boost/numeric/ublas/vector.hpp
@@ -88,7 +88,7 @@ namespace boost { namespace numeric { namespace ublas {
 	/// \param data container of type \c A
 	/// \todo remove this definition because \c size is not used
 	    BOOST_UBLAS_INLINE
-	    vector (size_type size, const array_type &data):
+        vector (size_type /*size*/, const array_type &data):
 	        vector_container<self_type> (),
 	        data_ (data) {}
 
@@ -1675,7 +1675,7 @@ namespace boost { namespace numeric { namespace ublas {
 
 	     // Element support
 	     BOOST_UBLAS_INLINE
-	     const_pointer find_element (size_type i) const {
+         const_pointer find_element (size_type /*i*/) const {
 	         return & zero_;
 	     }
 
@@ -2384,7 +2384,7 @@ namespace boost { namespace numeric { namespace ublas {
 
 	     // Resizing
 	     BOOST_UBLAS_INLINE
-	     void resize (size_type size, bool preserve = true) {
+         void resize (size_type size, bool /*preserve*/ = true) {
 	         if (size > N)
                  bad_size ().raise ();
 	         size_ = size;

--- a/include/boost/numeric/ublas/vector_proxy.hpp
+++ b/include/boost/numeric/ublas/vector_proxy.hpp
@@ -1303,8 +1303,8 @@ namespace boost { namespace numeric { namespace ublas {
 
         // Closure comparison
         BOOST_UBLAS_INLINE
-        bool same_closure (const vector_indirect &vr) const {
-return true;
+        bool same_closure (const vector_indirect &/*vr*/) const {
+            return true;
         }
 
         // Comparison


### PR DESCRIPTION
There is also an unused variable in: boost/numeric/ublas/functional.hpp:1138: unused parameter 'j'
but in this case it can't be commented out. boost::ignore_unused_variable_warning() defined in boost/concept_check.hpp could be used or similar function added to Ublas.
