### PR TITLE
Fix warnings for MSVC14

### DIFF
--- a/include/boost/numeric/ublas/detail/matrix_assign.hpp
+++ b/include/boost/numeric/ublas/detail/matrix_assign.hpp
@@ -75,21 +75,21 @@ namespace detail {
                 if (it2 != it2_end && it2e != it2e_end) {
                     size_type it2_index = it2.index2 (), it2e_index = it2e.index2 ();
                     while (true) {
-                        difference_type compare = it2_index - it2e_index;
-                        if (compare == 0) {
+                        difference_type compare2 = it2_index - it2e_index;
+                        if (compare2 == 0) {
                             ++ it2, ++ it2e;
                             if (it2 != it2_end && it2e != it2e_end) {
                                 it2_index = it2.index2 ();
                                 it2e_index = it2e.index2 ();
                             } else
                                 break;
-                        } else if (compare < 0) {
-                            increment (it2, it2_end, - compare);
+                        } else if (compare2 < 0) {
+                            increment (it2, it2_end, - compare2);
                             if (it2 != it2_end)
                                 it2_index = it2.index2 ();
                             else
                                 break;
-                        } else if (compare > 0) {
+                        } else if (compare2 > 0) {
                             if (conformant_restrict_type::other (it2e.index1 (), it2e.index2 ()))
                                 if (static_cast<value_type>(*it2e) != value_type/*zero*/())
                                     index.push_back (std::pair<size_type, size_type> (it2e.index1 (), it2e.index2 ()));
@@ -178,21 +178,21 @@ namespace detail {
                 if (it1 != it1_end && it1e != it1e_end) {
                     size_type it1_index = it1.index1 (), it1e_index = it1e.index1 ();
                     while (true) {
-                        difference_type compare = it1_index - it1e_index;
-                        if (compare == 0) {
+                        difference_type compare2 = it1_index - it1e_index;
+                        if (compare2 == 0) {
                             ++ it1, ++ it1e;
                             if (it1 != it1_end && it1e != it1e_end) {
                                 it1_index = it1.index1 ();
                                 it1e_index = it1e.index1 ();
                             } else
                                 break;
-                        } else if (compare < 0) {
-                            increment (it1, it1_end, - compare);
+                        } else if (compare2 < 0) {
+                            increment (it1, it1_end, - compare2);
                             if (it1 != it1_end)
                                 it1_index = it1.index1 ();
                             else
                                 break;
-                        } else if (compare > 0) {
+                        } else if (compare2 > 0) {
                             if (conformant_restrict_type::other (it1e.index1 (), it1e.index2 ()))
                                 if (static_cast<value_type>(*it1e) != value_type/*zero*/())
                                     index.push_back (std::pair<size_type, size_type> (it1e.index1 (), it1e.index2 ()));
@@ -1003,8 +1003,8 @@ namespace detail {
                 if (it2 != it2_end && it2e != it2e_end) {
                     size_type it2_index = it2.index2 (), it2e_index = it2e.index2 ();
                     while (true) {
-                        difference_type compare = it2_index - it2e_index;
-                        if (compare == 0) {
+                        difference_type compare2 = it2_index - it2e_index;
+                        if (compare2 == 0) {
                             functor_type::apply (*it2, *it2e);
                             ++ it2, ++ it2e;
                             if (it2 != it2_end && it2e != it2e_end) {
@@ -1012,18 +1012,18 @@ namespace detail {
                                 it2e_index = it2e.index2 ();
                             } else
                                 break;
-                        } else if (compare < 0) {
+                        } else if (compare2 < 0) {
                             if (!functor_type::computed) {
                                 functor_type::apply (*it2, expr_value_type/*zero*/());
                                 ++ it2;
                             } else
-                                increment (it2, it2_end, - compare);
+                                increment (it2, it2_end, - compare2);
                             if (it2 != it2_end)
                                 it2_index = it2.index2 ();
                             else
                                 break;
-                        } else if (compare > 0) {
-                            increment (it2e, it2e_end, compare);
+                        } else if (compare2 > 0) {
+                            increment (it2e, it2e_end, compare2);
                             if (it2e != it2e_end)
                                 it2e_index = it2e.index2 ();
                             else
@@ -1126,8 +1126,8 @@ namespace detail {
                 if (it1 != it1_end && it1e != it1e_end) {
                     size_type it1_index = it1.index1 (), it1e_index = it1e.index1 ();
                     while (true) {
-                        difference_type compare = it1_index - it1e_index;
-                        if (compare == 0) {
+                        difference_type compare2 = it1_index - it1e_index;
+                        if (compare2 == 0) {
                             functor_type::apply (*it1, *it1e);
                             ++ it1, ++ it1e;
                             if (it1 != it1_end && it1e != it1e_end) {
@@ -1135,18 +1135,18 @@ namespace detail {
                                 it1e_index = it1e.index1 ();
                             } else
                                 break;
-                        } else if (compare < 0) {
+                        } else if (compare2 < 0) {
                             if (!functor_type::computed) {
                                 functor_type::apply (*it1, expr_value_type/*zero*/()); // zeroing
                                 ++ it1;
                             } else
-                                increment (it1, it1_end, - compare);
+                                increment (it1, it1_end, - compare2);
                             if (it1 != it1_end)
                                 it1_index = it1.index1 ();
                             else
                                 break;
-                        } else if (compare > 0) {
-                            increment (it1e, it1e_end, compare);
+                        } else if (compare2 > 0) {
+                            increment (it1e, it1e_end, compare2);
                             if (it1e != it1e_end)
                                 it1e_index = it1e.index1 ();
                             else
@@ -1391,8 +1391,8 @@ namespace detail {
                 if (it2 != it2_end && it2e != it2e_end) {
                     size_type it2_index = it2.index2 (), it2e_index = it2e.index2 ();
                     while (true) {
-                        difference_type compare = it2_index - it2e_index;
-                        if (compare == 0) {
+                        difference_type compare2 = it2_index - it2e_index;
+                        if (compare2 == 0) {
                             functor_type::apply (*it2, *it2e);
                             ++ it2, ++ it2e;
                             if (it2 != it2_end && it2e != it2e_end) {
@@ -1400,14 +1400,14 @@ namespace detail {
                                 it2e_index = it2e.index2 ();
                             } else
                                 break;
-                        } else if (compare < 0) {
-                            increment (it2, it2_end, - compare);
+                        } else if (compare2 < 0) {
+                            increment (it2, it2_end, - compare2);
                             if (it2 != it2_end)
                                 it2_index = it2.index2 ();
                             else
                                 break;
-                        } else if (compare > 0) {
-                            increment (it2e, it2e_end, compare);
+                        } else if (compare2 > 0) {
+                            increment (it2e, it2e_end, compare2);
                             if (it2e != it2e_end)
                                 it2e_index = it2e.index2 ();
                             else
@@ -1516,8 +1516,8 @@ namespace detail {
                 if (it1 != it1_end && it1e != it1e_end) {
                     size_type it1_index = it1.index1 (), it1e_index = it1e.index1 ();
                     while (true) {
-                        difference_type compare = it1_index - it1e_index;
-                        if (compare == 0) {
+                        difference_type compare2 = it1_index - it1e_index;
+                        if (compare2 == 0) {
                             functor_type::apply (*it1, *it1e);
                             ++ it1, ++ it1e;
                             if (it1 != it1_end && it1e != it1e_end) {
@@ -1525,14 +1525,14 @@ namespace detail {
                                 it1e_index = it1e.index1 ();
                             } else
                                 break;
-                        }  else if (compare < 0) {
-                            increment (it1, it1_end, - compare);
+                        }  else if (compare2 < 0) {
+                            increment (it1, it1_end, - compare2);
                             if (it1 != it1_end)
                                 it1_index = it1.index1 ();
                             else
                                 break;
-                        } else if (compare > 0) {
-                            increment (it1e, it1e_end, compare);
+                        } else if (compare2 > 0) {
+                            increment (it1e, it1e_end, compare2);
                             if (it1e != it1e_end)
                                 it1e_index = it1e.index1 ();
                             else

--- a/include/boost/numeric/ublas/storage.hpp
+++ b/include/boost/numeric/ublas/storage.hpp
@@ -128,7 +128,7 @@ namespace boost { namespace numeric { namespace ublas {
                             }
                         }
                         else {
-                            for (pointer si = p_data; si != p_data + size_; ++si) {
+                            for (; si != p_data + size_; ++si) {
                                 alloc_.construct (di, *si);
                                 ++di;
                             }

--- a/test/test_assignment.cpp
+++ b/test/test_assignment.cpp
@@ -62,6 +62,7 @@ bool test_vector() {
     rb(0) = 1; rb(1) = 2; rb(2) = 3; rb(3)=10, rb(4)= 1; rb(5)=2; rb(6)=3;
     pass &= (mean_square(b-rb)<=TOL);
 
+    {
     V c(6), rc(6);
     c <<= 1, move(2), 3 ,4, 5, move(-5), 10, 10;
     rc(0) = 1; rc(1) = 10; rc(2) = 10; rc(3) = 3; rc(4) = 4; rc(5) = 5;
@@ -71,6 +72,7 @@ bool test_vector() {
     d <<= 1, move_to(3), 3 ,4, 5, move_to(1), 10, 10;
     rd(0) = 1; rd(1) = 10; rd(2) = 10; rd(3) = 3; rd(4) = 4; rd(5) = 5;
     pass &= (mean_square(d-rd)<=TOL);
+    }
 
     {
     V c(6), rc(6);

--- a/test/test_complex_norms.cpp
+++ b/test/test_complex_norms.cpp
@@ -62,7 +62,7 @@ BOOST_UBLAS_TEST_DEF ( test_float_complex_norm_2 ) {
     for (unsigned int i = 0; i < v.size(); ++i)
         v[i] = dComplex(i, i + 1);
 
-    const float expected = sqrt(44.0);
+    const double expected = sqrt(44.0);
 
     BOOST_UBLAS_DEBUG_TRACE( "norm is " << norm_2(v) );
     BOOST_UBLAS_TEST_CHECK(std::abs(norm_2(v) - expected) < TOL);


### PR DESCRIPTION
warning C4456: declaration of '...' hides previous local declaration
warning C4244: 'initializing': conversion from 'double' to 'const float', possible loss of data
