### PR TITLE
Fix metadata link to documentation.

### DIFF
--- a/meta/libraries.json
+++ b/meta/libraries.json
@@ -6,7 +6,6 @@
         "Mathias Koch"
     ],
     "description": "uBLAS provides matrix and vector classes as well as basic linear algebra routines. Several dense, packed and sparse storage schemes are supported.",
-    "documentation": "doc/index.htm",
     "category": [
         "Math"
     ],


### PR DESCRIPTION
The last release broke the link. The default works fine, so use that instead.
