### PR TITLE
Fix typo in fixed_matrix move-assignment

### DIFF
--- a/include/boost/numeric/ublas/matrix.hpp
+++ b/include/boost/numeric/ublas/matrix.hpp
@@ -1384,7 +1384,7 @@ namespace boost { namespace numeric {
 
         /*! @note "pass by value" the key idea to enable move semantics */
         BOOST_UBLAS_INLINE
-        fixed_matrix &operator = (matrix m) {
+        fixed_matrix &operator = (fixed_matrix && m) {
             assign_temporary(m);
             return *this;
         }


### PR DESCRIPTION
The move assignment operator= had an operand of "matrix", which is an
undefined type, causing a compile error.  Changing the type to "fixed_matrix"
solves the problem.

Since this is supposed to be a move-assignment operator, I made it take an
r-value reference as well, which seems to be the general agreed-upon way
to define this operator.

This is related to trac bug #10762