### PR TITLE
"template inline" instead of "inline template"

### DIFF
--- a/include/boost/numeric/ublas/storage.hpp
+++ b/include/boost/numeric/ublas/storage.hpp
@@ -777,8 +777,8 @@ namespace boost { namespace numeric { namespace ublas {
         BOOST_UBLAS_INLINE
         shallow_array_adaptor (size_type size, pointer data):
             size_ (size), own_ (false), data_ (data, leaker<value_type> ()) {}
-        BOOST_UBLAS_INLINE
         template <size_t N>
+        BOOST_UBLAS_INLINE
         shallow_array_adaptor (T (&data)[N]):
             size_ (N), own_ (false), data_ (data, leaker<value_type> ()) {}
 
@@ -833,13 +833,13 @@ namespace boost { namespace numeric { namespace ublas {
         void resize (size_type size, pointer data, value_type init) {
             resize_internal (size, data, init, true);
         }
-        BOOST_UBLAS_INLINE
         template <size_t N>
+        BOOST_UBLAS_INLINE
         void resize (T (&data)[N]) {
             resize_internal (N, data, value_type (), false);
         }
-        BOOST_UBLAS_INLINE
         template <size_t N>
+        BOOST_UBLAS_INLINE
         void resize (T (&data)[N], value_type init) {
             resize_internal (N, data, init, true);
         }


### PR DESCRIPTION
This is similar to 19eb8cf30af812c8434dfc7e5f0c6c7ded5477d0 and the header
can't be used without this fix.