### PR TITLE
fix availability of serialization::make_array

### DIFF
--- a/include/boost/numeric/ublas/storage.hpp
+++ b/include/boost/numeric/ublas/storage.hpp
@@ -19,6 +19,7 @@
 #endif
 
 #include <boost/serialization/array.hpp>
+#include <boost/serialization/array_wrapper.hpp>
 #include <boost/serialization/collection_size_type.hpp>
 #include <boost/serialization/nvp.hpp>
 


### PR DESCRIPTION
/media/data/libraries/src/boost/boost/numeric/ublas/storage.hpp:331:33: error: no member named 'make_array' in namespace 'boost::serialization'