### PR TITLE
Provide possible fix of misleading indentation.

### DIFF
--- a/include/boost/numeric/ublas/matrix_expression.hpp
+++ b/include/boost/numeric/ublas/matrix_expression.hpp
@@ -2221,10 +2221,10 @@ namespace boost { namespace numeric { namespace ublas {
                         index1 = it1_.index1 ();
                 }
                 size_type index2 = (*this) ().size1 ();
-                if (it2_ != it2_end_)
+                if (it2_ != it2_end_) {
                     if (it2_.index1 () <= i_)
                         ++ it2_;
-                    if (it2_ != it2_end_) {
+                    if (it2_ != it2_end_)
                         index2 = it2_.index1 ();
                 }
                 i_ = (std::min) (index1, index2);


### PR DESCRIPTION
I get a warning of a misleading indentation when I compile odeint/examples/harmonic_oscillator.cpp with gcc version 7.2.0 and warning flag -Wall.  The warning goes away with the fix.  I'm not sure that the fix is correct, but it looks right and does make the if/then block for it2 more consistent with the if/then block for it1 immediately above it.