### PR TITLE
Fix broken links in documentation.

### DIFF
--- a/doc/bounded_array.html
+++ b/doc/bounded_array.html
@@ -81,17 +81,17 @@ member inside this model of the concept.</li>
 <th>Where defined</th>
 <th>Description</th>
 </tr>
-<tr><td><code>value_type</code></td><td><a href="http://www.sgi.com/tech/stl/Container.html">Container</a></td><td></tr>
-<tr><td><code>pointer</code></td><td><a href="http://www.sgi.com/tech/stl/Container.html">Container</a></td><td>Defined as <code>value_type*</code></td></tr>
-<tr><td><code>const_pointer</code></td><td><a href="http://www.sgi.com/tech/stl/Container.html">Container</a></td><td>Defined as <code>const value_type*</code></td></tr>
-<tr><td><code>reference</code></td><td><a href="http://www.sgi.com/tech/stl/Container.html">Container</a></td><td>Defined as <code>value_type&amp;</code></td></tr>
-<tr><td><code>const_reference</code></td><td><a href="http://www.sgi.com/tech/stl/Container.html">Container</a></td><td>Defined as <code>const value_type&amp;</code></td></tr>
-<tr><td><code>size_type</code></td><td><a href="http://www.sgi.com/tech/stl/Container.html">Container</a></td><td>Defined as <code>Alloc::size_type</code></td></tr>
-<tr><td><code>difference_type</code></td><td><a href="http://www.sgi.com/tech/stl/Container.html">Container</a></td><td>Defined as <code>Alloc::difference_type</code></td></tr>
-<tr><td><code>iterator</code></td><td><a href="http://www.sgi.com/tech/stl/Container.html">Container</a></td><td>Defined as <code>pointer</code></td></tr>
-<tr><td><code>const_iterator</code></td><td><a href="http://www.sgi.com/tech/stl/Container.html">Container</a></td><td>Defined as <code>const_pointer</code></td></tr>
-<tr><td><code>revere_iterator</code></td><td><a href="http://www.sgi.com/tech/stl/Container.html">Container</a></td><td>Defined as <code>std::reverse_iterator&lt;iterator&gt;</code></td></tr>
-<tr><td><code>const_revere_iterator</code></td><td><a href="http://www.sgi.com/tech/stl/Container.html">Container</a></td><td>Defined as <code>std::reverse_iterator&lt;const_iterator&gt;</code></td></tr>
+<tr><td><code>value_type</code></td><td><a href="http://www.boost.org/sgi/stl/Container.html">Container</a></td><td></tr>
+<tr><td><code>pointer</code></td><td><a href="http://www.boost.org/sgi/stl/Container.html">Container</a></td><td>Defined as <code>value_type*</code></td></tr>
+<tr><td><code>const_pointer</code></td><td><a href="http://www.boost.org/sgi/stl/Container.html">Container</a></td><td>Defined as <code>const value_type*</code></td></tr>
+<tr><td><code>reference</code></td><td><a href="http://www.boost.org/sgi/stl/Container.html">Container</a></td><td>Defined as <code>value_type&amp;</code></td></tr>
+<tr><td><code>const_reference</code></td><td><a href="http://www.boost.org/sgi/stl/Container.html">Container</a></td><td>Defined as <code>const value_type&amp;</code></td></tr>
+<tr><td><code>size_type</code></td><td><a href="http://www.boost.org/sgi/stl/Container.html">Container</a></td><td>Defined as <code>Alloc::size_type</code></td></tr>
+<tr><td><code>difference_type</code></td><td><a href="http://www.boost.org/sgi/stl/Container.html">Container</a></td><td>Defined as <code>Alloc::difference_type</code></td></tr>
+<tr><td><code>iterator</code></td><td><a href="http://www.boost.org/sgi/stl/Container.html">Container</a></td><td>Defined as <code>pointer</code></td></tr>
+<tr><td><code>const_iterator</code></td><td><a href="http://www.boost.org/sgi/stl/Container.html">Container</a></td><td>Defined as <code>const_pointer</code></td></tr>
+<tr><td><code>revere_iterator</code></td><td><a href="http://www.boost.org/sgi/stl/Container.html">Container</a></td><td>Defined as <code>std::reverse_iterator&lt;iterator&gt;</code></td></tr>
+<tr><td><code>const_revere_iterator</code></td><td><a href="http://www.boost.org/sgi/stl/Container.html">Container</a></td><td>Defined as <code>std::reverse_iterator&lt;const_iterator&gt;</code></td></tr>
 <tr>
 <td><code>bounded_array ()</code></td>
 <td><a href="storage_concept.html">Storage</a></td>
@@ -109,12 +109,12 @@ member inside this model of the concept.</li>
 </tr>
 <tr>
 <td><code>bounded_array (const bounded_array &amp;c)</code></td>
-<td><a href="http://www.sgi.com/tech/stl/Container.html">Container</a></td>
+<td><a href="http://www.boost.org/sgi/stl/Container.html">Container</a></td>
 <td>The copy constructor.</td>
 </tr>
 <tr>
 <td><code>~bounded_array ()</code></td>
-<td><a href="http://www.sgi.com/tech/stl/Container.html">Container</a></td>
+<td><a href="http://www.boost.org/sgi/stl/Container.html">Container</a></td>
 <td>Deallocates the <code>bounded_array</code> itself.</td>
 </tr>
 <tr>
@@ -129,22 +129,22 @@ member inside this model of the concept.</li>
 </tr>
 <tr>
 <td><code>size_type size () const</code></td>
-<td><a href="http://www.sgi.com/tech/stl/Container.html">Container</a></td>
+<td><a href="http://www.boost.org/sgi/stl/Container.html">Container</a></td>
 <td>Returns the size of the <code>bounded_array</code>.</td>
 </tr>
 <tr>
 <td><code>const_reference operator [] (size_type i) const</code></td>
-<td><a href="http://www.sgi.com/tech/stl/Container.html">Container</a></td>
+<td><a href="http://www.boost.org/sgi/stl/Container.html">Container</a></td>
 <td>Returns a <code>const</code> reference of the <code>i</code> -th element.</td>
 </tr>
 <tr>
 <td><code>reference operator [] (size_type i)</code></td>
-<td><a href="http://www.sgi.com/tech/stl/Container.html">Container</a></td>
+<td><a href="http://www.boost.org/sgi/stl/Container.html">Container</a></td>
 <td>Returns a reference of the <code>i</code>-th element.</td>
 </tr>
 <tr>
 <td><code>bounded_array &amp;operator = (const bounded_array &amp;a)</code></td>
-<td><a href="http://www.sgi.com/tech/stl/Container.html">Container</a></td>
+<td><a href="http://www.boost.org/sgi/stl/Container.html">Container</a></td>
 <td>The assignment operator.</td>
 </tr>
 <tr>
@@ -154,47 +154,47 @@ member inside this model of the concept.</li>
 </tr>
 <tr>
 <td><code>void swap (bounded_array &amp;a)</code></td>
-<td><a href="http://www.sgi.com/tech/stl/Container.html">Container</a></td>
+<td><a href="http://www.boost.org/sgi/stl/Container.html">Container</a></td>
 <td>Swaps the contents of the arrays.</td>
 </tr>
 <tr>
 <td><code>const_iterator begin () const</code></td>
-<td><a href="http://www.sgi.com/tech/stl/Container.html">Container</a></td>
+<td><a href="http://www.boost.org/sgi/stl/Container.html">Container</a></td>
 <td>Returns a <code>const_iterator</code> pointing to the beginning of the <code>bounded_array</code>.</td>
 </tr>
 <tr>
 <td><code>const_iterator end () const</code></td>
-<td><a href="http://www.sgi.com/tech/stl/Container.html">Container</a></td>
+<td><a href="http://www.boost.org/sgi/stl/Container.html">Container</a></td>
 <td>Returns a <code>const_iterator</code> pointing to the end of the <code>bounded_array</code>.</td> 
 </tr>
 <tr>
 <td><code>iterator begin ()</code></td>
-<td><a href="http://www.sgi.com/tech/stl/Container.html">Container</a></td>
+<td><a href="http://www.boost.org/sgi/stl/Container.html">Container</a></td>
 <td>Returns a <code>iterator</code> pointing to the beginning of the <code>bounded_array</code>.</td>
 </tr>
 <tr>
 <td><code>iterator end ()</code></td>
-<td><a href="http://www.sgi.com/tech/stl/Container.html">Container</a></td>
+<td><a href="http://www.boost.org/sgi/stl/Container.html">Container</a></td>
 <td>Returns a <code>iterator</code> pointing to the end of the <code>bounded_array</code>.</td>
 </tr>
 <tr>
 <td><code>const_reverse_iterator rbegin () const</code></td>
-<td><a href="http://www.sgi.com/tech/stl/ReversibleContainer.html">Reversible Container</a></td>
+<td><a href="http://www.boost.org/sgi/stl/ReversibleContainer.html">Reversible Container</a></td>
 <td>Returns a <code>const_reverse_iterator</code> pointing to the beginning of the reversed <code>bounded_array</code>.</td>
 </tr>
 <tr>
 <td><code>const_reverse_iterator rend () const</code></td>
-<td><a href="http://www.sgi.com/tech/stl/ReversibleContainer.html">Reversible Container</a></td>
+<td><a href="http://www.boost.org/sgi/stl/ReversibleContainer.html">Reversible Container</a></td>
 <td>Returns a <code>const_reverse_iterator</code> pointing to the end of the reversed <code>bounded_array</code>.</td>
 </tr>
 <tr>
 <td><code>reverse_iterator rbegin ()</code></td>
-<td><a href="http://www.sgi.com/tech/stl/ReversibleContainer.html">Reversible Container</a></td>
+<td><a href="http://www.boost.org/sgi/stl/ReversibleContainer.html">Reversible Container</a></td>
 <td>Returns a <code>reverse_iterator</code> pointing to the beginning of the reversed <code>bounded_array</code>.</td>
 </tr>
 <tr>
 <td><code>reverse_iterator rend ()</code></td>
-<td><a href="http://www.sgi.com/tech/stl/ReversibleContainer.html">Reversible Container</a></td>
+<td><a href="http://www.boost.org/sgi/stl/ReversibleContainer.html">Reversible Container</a></td>
 <td>Returns a <code>reverse_iterator</code> pointing to the end of the reversed <code>bounded_array</code>.</td>
 </tr>
 </tbody>

--- a/doc/container_concept.html
+++ b/doc/container_concept.html
@@ -20,7 +20,7 @@
 <p>A Vector describes common aspects of dense, packed and sparse
 vectors.</p>
 <h4>Refinement of</h4>
-<p><a href="http://www.sgi.com/tech/stl/DefaultConstructible.html">DefaultConstructible</a>,
+<p><a href="http://www.boost.org/sgi/stl/DefaultConstructible.html">DefaultConstructible</a>,
 <a href="expression_concept.html#vector_expression">Vector Expression</a>
 <a href="#vector_expression_note">[1]</a>.</p>
 <h4>Associated types</h4>
@@ -68,7 +68,7 @@ Dense Vector ONLY. The type of underlying storage array used to store the elemen
 </table>
 <h4>Definitions</h4>
 <h4>Valid expressions</h4>
-<p>In addition to the expressions defined in <a href="http://www.sgi.com/tech/stl/DefaultConstructible.html">DefaultConstructible</a>,
+<p>In addition to the expressions defined in <a href="http://www.boost.org/sgi/stl/DefaultConstructible.html">DefaultConstructible</a>,
 <a href="expression_concept.html#vector_expression">Vector Expression</a> the following expressions must be valid.</p>
 <table border="1" summary="expressions">
 <tbody>
@@ -216,7 +216,7 @@ used for both vectors and matrices.</p>
 <p>A Matrix describes common aspects of dense, packed and sparse
 matrices.</p>
 <h4>Refinement of</h4>
-<p><a href="http://www.sgi.com/tech/stl/DefaultConstructible.html">DefaultConstructible</a>,
+<p><a href="http://www.boost.org/sgi/stl/DefaultConstructible.html">DefaultConstructible</a>,
 <a href="expression_concept.html#matrix_expression">Matrix Expression</a>
 <a href="#matrix_expression_note">[1]</a>
 .</p>

--- a/doc/index.html
+++ b/doc/index.html
@@ -24,7 +24,7 @@ symmetric, hermitian and sparse matrices. Views into vectors and matrices can be
 adaptor classes and indirect arrays. The library covers the usual basic linear algebra operations on vectors and matrices: reductions like
 different norms, addition and subtraction of vectors and matrices and multiplication with a scalar, inner and outer
 products of vectors, matrix vector and matrix matrix products and triangular solver. The glue between containers, views
-and expression templated operations is a mostly <a href="http://www.sgi.com/tech/stl">STL</a> conforming iterator interface.</p>
+and expression templated operations is a mostly <a href="http://www.boost.org/sgi/stl/">STL</a> conforming iterator interface.</p>
 
 <h2>Documentation</h2>
 

--- a/doc/storage_concept.html
+++ b/doc/storage_concept.html
@@ -22,12 +22,12 @@
 the Sequence concept however is that the Storage concept does not require default-initialisation of its
 elements.
 <h4>Refinement of</h4>
-<a href="http://www.sgi.com/tech/stl/RandomAccessContainer.html">Random Access Container</a>
+<a href="http://www.boost.org/sgi/stl/RandomAccessContainer.html">Random Access Container</a>
 and 
-<a href="http://www.sgi.com/tech/stl/DefaultConstructible.html">Default Constructible</a>
+<a href="http://www.boost.org/sgi/stl/DefaultConstructible.html">Default Constructible</a>
 <h4>Associated types</h4>
 No additional types beyond those defined by 
-<a href="http://www.sgi.com/tech/stl/RandomAccessContainer.html">Random Access Container</a>
+<a href="http://www.boost.org/sgi/stl/RandomAccessContainer.html">Random Access Container</a>
 <h4>Notation</h4>
 <table summary="storage types">
 <tr><td><tt>X</tt></td><td>A type that is model of Storage</td></tr>
@@ -38,16 +38,16 @@ No additional types beyond those defined by
 <h4>Definitions</h4>
 <h4>Valid expressions</h4>
 In addition to the expressions defined in 
-<a href="http://www.sgi.com/tech/stl/RandomAccessContainer.html">Random Access Container</a>,
+<a href="http://www.boost.org/sgi/stl/RandomAccessContainer.html">Random Access Container</a>,
 and 
-<a href="http://www.sgi.com/tech/stl/DefaultConstructible.html">Default Constructible</a>
+<a href="http://www.boost.org/sgi/stl/DefaultConstructible.html">Default Constructible</a>
 the following expressions must be valid:
 <table border="1" summary="type requirements">
 <TR><TH>Name</TH><TH>Expression</TH><TH>Type requirements</TH><TH>Return type</TH></TR>
 <TR>
 <td>Size constructor</td>
 <td><tt>X(n)</tt></td>
-<td>T is <a href="http://www.sgi.com/tech/stl/DefaultConstructible.html">DefaultConstructible</a></td>
+<td>T is <a href="http://www.boost.org/sgi/stl/DefaultConstructible.html">DefaultConstructible</a></td>
 <td><tt>X</tt></td>
 </TR>
 <TR>
@@ -59,7 +59,7 @@ the following expressions must be valid:
 <TR>
 <TD>Range constructor</TD>
 <TD><tt>X(i, j)</tt></TD>
-<TD><tt>i</tt> and <tt>j</tt> are <A href="http://www.sgi.com/tech/stl/InputIterator.html">Input Iterators</A> whose value type is convertible to <tt>T</tt> </TD>
+<TD><tt>i</tt> and <tt>j</tt> are <A href="http://www.boost.org/sgi/stl/InputIterator.html">Input Iterators</A> whose value type is convertible to <tt>T</tt> </TD>
 <TD><tt>X</tt> </TD>
 </TR>
 <TR>

--- a/doc/unbounded_array.html
+++ b/doc/unbounded_array.html
@@ -78,17 +78,17 @@ member inside this model of the concept.</li>
 <th>Where defined</th>
 <th>Description</th>
 </tr>
-<tr><td><code>value_type</code></td><td><a href="http://www.sgi.com/tech/stl/Container.html">Container</a></td><td></tr>
-<tr><td><code>pointer</code></td><td><a href="http://www.sgi.com/tech/stl/Container.html">Container</a></td><td>Defined as <code>value_type*</code></td></tr>
-<tr><td><code>const_pointer</code></td><td><a href="http://www.sgi.com/tech/stl/Container.html">Container</a></td><td>Defined as <code>const value_type*</code></td></tr>
-<tr><td><code>reference</code></td><td><a href="http://www.sgi.com/tech/stl/Container.html">Container</a></td><td>Defined as <code>value_type&amp;</code></td></tr>
-<tr><td><code>const_reference</code></td><td><a href="http://www.sgi.com/tech/stl/Container.html">Container</a></td><td>Defined as <code>const value_type&amp;</code></td></tr>
-<tr><td><code>size_type</code></td><td><a href="http://www.sgi.com/tech/stl/Container.html">Container</a></td><td>Defined as <code>Alloc::size_type</code></td></tr>
-<tr><td><code>difference_type</code></td><td><a href="http://www.sgi.com/tech/stl/Container.html">Container</a></td><td>Defined as <code>Alloc::difference_type</code></td></tr>
-<tr><td><code>iterator</code></td><td><a href="http://www.sgi.com/tech/stl/Container.html">Container</a></td><td>Defined as <code>pointer</code></td></tr>
-<tr><td><code>const_iterator</code></td><td><a href="http://www.sgi.com/tech/stl/Container.html">Container</a></td><td>Defined as <code>const_pointer</code></td></tr>
-<tr><td><code>revere_iterator</code></td><td><a href="http://www.sgi.com/tech/stl/Container.html">Container</a></td><td>Defined as <code>std::reverse_iterator&lt;iterator&gt;</code></td></tr>
-<tr><td><code>const_revere_iterator</code></td><td><a href="http://www.sgi.com/tech/stl/Container.html">Container</a></td><td>Defined as <code>std::reverse_iterator&lt;const_iterator&gt;</code></td></tr>
+<tr><td><code>value_type</code></td><td><a href="http://www.boost.org/sgi/stl/Container.html">Container</a></td><td></tr>
+<tr><td><code>pointer</code></td><td><a href="http://www.boost.org/sgi/stl/Container.html">Container</a></td><td>Defined as <code>value_type*</code></td></tr>
+<tr><td><code>const_pointer</code></td><td><a href="http://www.boost.org/sgi/stl/Container.html">Container</a></td><td>Defined as <code>const value_type*</code></td></tr>
+<tr><td><code>reference</code></td><td><a href="http://www.boost.org/sgi/stl/Container.html">Container</a></td><td>Defined as <code>value_type&amp;</code></td></tr>
+<tr><td><code>const_reference</code></td><td><a href="http://www.boost.org/sgi/stl/Container.html">Container</a></td><td>Defined as <code>const value_type&amp;</code></td></tr>
+<tr><td><code>size_type</code></td><td><a href="http://www.boost.org/sgi/stl/Container.html">Container</a></td><td>Defined as <code>Alloc::size_type</code></td></tr>
+<tr><td><code>difference_type</code></td><td><a href="http://www.boost.org/sgi/stl/Container.html">Container</a></td><td>Defined as <code>Alloc::difference_type</code></td></tr>
+<tr><td><code>iterator</code></td><td><a href="http://www.boost.org/sgi/stl/Container.html">Container</a></td><td>Defined as <code>pointer</code></td></tr>
+<tr><td><code>const_iterator</code></td><td><a href="http://www.boost.org/sgi/stl/Container.html">Container</a></td><td>Defined as <code>const_pointer</code></td></tr>
+<tr><td><code>revere_iterator</code></td><td><a href="http://www.boost.org/sgi/stl/Container.html">Container</a></td><td>Defined as <code>std::reverse_iterator&lt;iterator&gt;</code></td></tr>
+<tr><td><code>const_revere_iterator</code></td><td><a href="http://www.boost.org/sgi/stl/Container.html">Container</a></td><td>Defined as <code>std::reverse_iterator&lt;const_iterator&gt;</code></td></tr>
 <tr><td><font color="blue">allocator_type</font></td><td></td><td>Defined as ALLOC</td></tr>
 <tr>
 <td><code><em>explicit</em> unbounded_array (<em>ALLOC &amp;a = ALLOC()</em>)</code></td>
@@ -107,12 +107,12 @@ member inside this model of the concept.</li>
 </tr>
 <tr>
 <td><code>unbounded_array (const unbounded_array &amp;a)</code></td>
-<td><a href="http://www.sgi.com/tech/stl/Container.html">Container</a></td>
+<td><a href="http://www.boost.org/sgi/stl/Container.html">Container</a></td>
 <td>The copy constructor.</td>
 </tr>
 <tr>
 <td><code>~unbounded_array ()</code></td>
-<td><a href="http://www.sgi.com/tech/stl/Container.html">Container</a></td>
+<td><a href="http://www.boost.org/sgi/stl/Container.html">Container</a></td>
 <td>Deallocates the <code>unbounded_array</code> itself.</td>
 </tr>
 <tr>
@@ -127,22 +127,22 @@ member inside this model of the concept.</li>
 </tr>
 <tr>
 <td><code>size_type size () const</code></td>
-<td><a href="http://www.sgi.com/tech/stl/Container.html">Container</a></td>
+<td><a href="http://www.boost.org/sgi/stl/Container.html">Container</a></td>
 <td>Returns the size of the <code>unbounded_array</code>.</td>
 </tr>
 <tr>
 <td><code>const_reference operator [] (size_type i) const</code></td>
-<td><a href="http://www.sgi.com/tech/stl/Container.html">Container</a></td>
+<td><a href="http://www.boost.org/sgi/stl/Container.html">Container</a></td>
 <td>Returns a <code>const</code> reference of the <code>i</code> -th element.</td>
 </tr>
 <tr>
 <td><code>reference operator [] (size_type i)</code></td>
-<td><a href="http://www.sgi.com/tech/stl/Container.html">Container</a></td>
+<td><a href="http://www.boost.org/sgi/stl/Container.html">Container</a></td>
 <td>Returns a reference of the <code>i</code>-th element.</td>
 </tr>
 <tr>
 <td><code>unbounded_array &amp;operator = (const unbounded_array &amp;a)</code></td>
-<td><a href="http://www.sgi.com/tech/stl/Container.html">Container</a></td>
+<td><a href="http://www.boost.org/sgi/stl/Container.html">Container</a></td>
 <td>The assignment operator.</td>
 </tr>
 <tr>
@@ -152,51 +152,51 @@ member inside this model of the concept.</li>
 </tr>
 <tr>
 <td><code>void swap (unbounded_array &amp;a)</code></td>
-<td><a href="http://www.sgi.com/tech/stl/Container.html">Container</a></td>
+<td><a href="http://www.boost.org/sgi/stl/Container.html">Container</a></td>
 <td>Swaps the contents of the arrays.</td>
 </tr>
 <tr>
 <td><code>const_iterator begin () const</code></td>
-<td><a href="http://www.sgi.com/tech/stl/Container.html">Container</a></td>
+<td><a href="http://www.boost.org/sgi/stl/Container.html">Container</a></td>
 <td>Returns a <code>const_iterator</code> pointing to the beginning
 of the <code>unbounded_array</code>.</td>
 </tr>
 <tr>
 <td><code>const_iterator end () const</code></td>
-<td><a href="http://www.sgi.com/tech/stl/Container.html">Container</a></td>
+<td><a href="http://www.boost.org/sgi/stl/Container.html">Container</a></td>
 <td>Returns a <code>const_iterator</code> pointing to the end of
 the <code>unbounded_array</code>.</td>
 </tr>
 <tr>
 <td><code>iterator begin ()</code></td>
-<td><a href="http://www.sgi.com/tech/stl/Container.html">Container</a></td>
+<td><a href="http://www.boost.org/sgi/stl/Container.html">Container</a></td>
 <td>Returns a <code>iterator</code> pointing to the beginning of
 the <code>unbounded_array</code>.</td>
 </tr>
 <tr>
 <td><code>iterator end ()</code></td>
-<td><a href="http://www.sgi.com/tech/stl/Container.html">Container</a></td>
+<td><a href="http://www.boost.org/sgi/stl/Container.html">Container</a></td>
 <td>Returns a <code>iterator</code> pointing to the end of the
 <code>unbounded_array</code>.</td>
 </tr>
 <tr>
 <td><code>const_reverse_iterator rbegin () const</code></td>
-<td><a href="http://www.sgi.com/tech/stl/ReversibleContainer.html">Reversible Container</a></td>
+<td><a href="http://www.boost.org/sgi/stl/ReversibleContainer.html">Reversible Container</a></td>
 <td>Returns a <code>const_reverse_iterator</code> pointing to the beginning of the reversed <code>unbounded_array</code>.</td>
 </tr>
 <tr>
 <td><code>const_reverse_iterator rend () const</code></td>
-<td><a href="http://www.sgi.com/tech/stl/ReversibleContainer.html">Reversible Container</a></td>
+<td><a href="http://www.boost.org/sgi/stl/ReversibleContainer.html">Reversible Container</a></td>
 <td>Returns a <code>const_reverse_iterator</code> pointing to the end of the reversed <code>unbounded_array</code>.</td>
 </tr>
 <tr>
 <td><code>reverse_iterator rbegin ()</code></td>
-<td><a href="http://www.sgi.com/tech/stl/ReversibleContainer.html">Reversible Container</a></td>
+<td><a href="http://www.boost.org/sgi/stl/ReversibleContainer.html">Reversible Container</a></td>
 <td>Returns a <code>reverse_iterator</code> pointing to the beginning of the reversed <code>unbounded_array</code>.</td>
 </tr>
 <tr>
 <td><code>reverse_iterator rend ()</code></td>
-<td><a href="http://www.sgi.com/tech/stl/ReversibleContainer.html">Reversible Container</a></td>
+<td><a href="http://www.boost.org/sgi/stl/ReversibleContainer.html">Reversible Container</a></td>
 <td>Returns a <code>reverse_iterator</code> pointing to the end of the reversed <code>unbounded_array</code>.</td>
 </tr>
 </tbody>

--- a/doc/vector.html
+++ b/doc/vector.html
@@ -59,12 +59,12 @@ int main () {
 </table>
 <h4>Model of</h4>
 <p><a href="container_concept.html#vector">Vector</a>,
-<a href="http://www.sgi.com/tech/stl/RandomAccessContainer.html">RandomAccessContainer</a>
+<a href="http://www.boost.org/sgi/stl/RandomAccessContainer.html">RandomAccessContainer</a>
 </p>
 <h4>Type requirements</h4>
 <p>None, except for those imposed by the requirements of <a href=
 "container_concept.html#vector">Vector</a>
-and <a href="http://www.sgi.com/tech/stl/RandomAccessContainer.html">RandomAccessContainer</a>.</p>
+and <a href="http://www.boost.org/sgi/stl/RandomAccessContainer.html">RandomAccessContainer</a>.</p>
 <h4>Public base classes</h4>
 <p><code>vector_container&lt;vector&lt;T, A&gt; &gt;</code></p>
 <h4>Members</h4>
@@ -163,12 +163,12 @@ preseved when specified.</td>
 </tr>
 <tr>
 <td><code>size_type max_size () const</code></td>
-<td><a href="http://www.sgi.com/tech/stl/RandomAccessContainer.html">RandomAccessContainer</a></td>
+<td><a href="http://www.boost.org/sgi/stl/RandomAccessContainer.html">RandomAccessContainer</a></td>
 <td>Returns the upper bound on the size of the <code>vector</code>.</td>
 </tr>
 <tr>
 <td><code>bool empty () const</code></td>
-<td><a href="http://www.sgi.com/tech/stl/RandomAccessContainer.html">RandomAccessContainer</a></td>
+<td><a href="http://www.boost.org/sgi/stl/RandomAccessContainer.html">RandomAccessContainer</a></td>
 <td>Equivilent to <code>size () == 0</code>.</td>
 </tr>
 <tr>


### PR DESCRIPTION
Some documentation links currently point to pages that HP retired along with the rest of the SGI STL website. These links now point to the Boost mirror site.