### PR TITLE
Get rid of warning about misleading indentation in matrix_expression.hpp

### DIFF
--- a/include/boost/numeric/ublas/matrix_expression.hpp
+++ b/include/boost/numeric/ublas/matrix_expression.hpp
@@ -2221,11 +2221,12 @@ namespace boost { namespace numeric { namespace ublas {
                         index1 = it1_.index1 ();
                 }
                 size_type index2 = (*this) ().size1 ();
-                if (it2_ != it2_end_)
+                if (it2_ != it2_end_) {
                     if (it2_.index1 () <= i_)
                         ++ it2_;
                     if (it2_ != it2_end_) {
                         index2 = it2_.index1 ();
+                    }
                 }
                 i_ = (std::min) (index1, index2);
             }


### PR DESCRIPTION
This adds braces and fixes indentation that results in compilation warnings.

(Not sure if it is correct to target the `develop` branch or if this should go against `master`).