### PR TITLE
Fix for Appveyor CI Failures

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,10 +21,14 @@ environment:
       TOOLSET: msvc-14.0
       CXXSTD: 11
 
-cache:
-  - c:\tools\vcpkg\installed\
+# cache:
+  # - c:\tools\vcpkg\installed\
 
 install:
+  - cd "C:\Tools\vcpkg"
+  - git pull
+  - .\bootstrap-vcpkg.bat
+  - cd %appveyor_build_folder%
   # Install OpenCL runtime (driver) for Intel / Xeon package
   - appveyor DownloadFile "http://registrationcenter-download.intel.com/akdlm/irc_nas/9022/opencl_runtime_16.1.1_x64_setup.msi"
   - start /wait msiexec /i opencl_runtime_16.1.1_x64_setup.msi /qn  /l*v msiexec2.log


### PR DESCRIPTION
Recently due to some changes to vcpkg the CI was failing to work with VS2017 using cached vcpkg. This is however fixed if we update the vcpkg. To prevent this from happening in future I am adding the upgrade to vcpkg as a pre-step for building our code.