### PR TITLE
C++20/gcc10 removed allocator construct/destroy

### DIFF
--- a/include/boost/numeric/ublas/storage.hpp
+++ b/include/boost/numeric/ublas/storage.hpp
@@ -76,7 +76,11 @@ namespace boost { namespace numeric { namespace ublas {
 #pragma warning(pop)
 #endif
                   for (pointer d = data_; d != data_ + size_; ++d)
+#if __cplusplus >= 201703L
+                      std::allocator_traits<ALLOC>::construct (alloc_, d, value_type());
+#else
                       alloc_.construct(d, value_type());
+#endif
               }
           }
           else
@@ -149,17 +153,29 @@ namespace boost { namespace numeric { namespace ublas {
                         pointer di = data_;
                         if (size < size_) {
                             for (; di != data_ + size; ++di) {
+#if __cplusplus >= 201703L
+                                std::allocator_traits<ALLOC>::construct (alloc_, di, *si);
+#else
                                 alloc_.construct (di, *si);
+#endif
                                 ++si;
                             }
                         }
                         else {
                             for (; si != p_data + size_; ++si) {
+#if __cplusplus >= 201703L
+                                std::allocator_traits<ALLOC>::construct (alloc_, di, *si);
+#else
                                 alloc_.construct (di, *si);
+#endif
                                 ++di;
                             }
                             for (; di != data_ + size; ++di) {
+#if __cplusplus >= 201703L
+                                std::allocator_traits<ALLOC>::construct (alloc_, di, init);
+#else
                                 alloc_.construct (di, init);
+#endif
                             }
                         }
                     }
@@ -174,7 +190,11 @@ namespace boost { namespace numeric { namespace ublas {
 #pragma warning(pop)
 #endif
                             for (pointer di = data_; di != data_ + size; ++di)
+#if __cplusplus >= 201703L
+                                std::allocator_traits<ALLOC>::construct(alloc_, di, value_type());
+#else
                                 alloc_.construct (di, value_type());
+#endif
                         }
                     }
                 }
@@ -190,7 +210,11 @@ namespace boost { namespace numeric { namespace ublas {
 #pragma warning(pop)
 #endif
                         for (pointer si = p_data; si != p_data + size_; ++si)
+#if __cplusplus >= 201703L
+                            std::allocator_traits<ALLOC>::destroy (alloc_, si);
+#else
                             alloc_.destroy (si);
+#endif
                     }
                     alloc_.deallocate (p_data, size_);
                 }


### PR DESCRIPTION
std::allocator<T>::construct/destroy were deprecated in C++17 and removed in C++20, in favor of std::allocator_traits<T>::construct/destroy, which were introduced in C++11. (https://en.cppreference.com/w/cpp/memory/allocator_traits/construct). They are gone in gcc10. This fix switches to the the latter for C++17 and greater, enabling compilation with gcc 10+.