### PR TITLE
bug in test/tensor/test_static_functions.cpp with memory leak fixed.

### DIFF
--- a/include/boost/numeric/ublas/tensor/fixed_rank_extents.hpp
+++ b/include/boost/numeric/ublas/tensor/fixed_rank_extents.hpp
@@ -90,7 +90,7 @@ struct basic_fixed_rank_extents
     }
     
     constexpr basic_fixed_rank_extents(const_iterator begin, const_iterator end){
-        if( std::distance(begin,end) > _size ){
+        if( std::distance(begin,end) < 0 || static_cast<std::size_t>(std::distance(begin,end)) > _size){
             throw std::out_of_range("boost::numeric::ublas::basic_fixed_rank_extents(): initializer list size is greater than _size");
         }
         

--- a/include/boost/numeric/ublas/tensor/static_extents.hpp
+++ b/include/boost/numeric/ublas/tensor/static_extents.hpp
@@ -6,8 +6,7 @@
 //  accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 //
-//  The authors gratefully acknowledge the support of
-//  Google
+//  The authors gratefully acknowledge the support of Google
 //
 
 #ifndef _BOOST_NUMERIC_UBLAS_TENSOR_STATIC_EXTENTS_HPP_

--- a/test/tensor/test_fixed_rank_functions.cpp
+++ b/test/tensor/test_fixed_rank_functions.cpp
@@ -357,7 +357,7 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE( test_fixed_rank_tensor_outer_prod, value,  tes
         using extents_type_1 = typename std::decay<decltype(n1)>::type;             
         using tensor_type_1 = ublas::fixed_rank_tensor<value_type, extents_type_1::_size, layout_type>;
         auto a  = tensor_type_1(n1, value_type(2));
-        for_each_tuple(fixed_rank_extents,[&](auto const& J, auto const& n2){
+        for_each_tuple(fixed_rank_extents,[&](auto const& /*J*/, auto const& n2){
             using extents_type_2 = typename std::decay<decltype(n2)>::type;             
             using tensor_type_2 = ublas::fixed_rank_tensor<value_type, extents_type_2::_size, layout_type>;
             auto b  = tensor_type_2(n2, value_type(1));
@@ -370,10 +370,10 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE( test_fixed_rank_tensor_outer_prod, value,  tes
 
     });
 
-    for_each_tuple(fixed_rank_extents,[&](auto const& I, auto const& n1){             
+    for_each_tuple(fixed_rank_extents,[&](auto const& I, auto const& /*n1*/){
         using tensor_type_1 = ublas::dynamic_tensor<value_type, layout_type>;
         auto a  = tensor_type_1(extents[I], value_type(2));
-        for_each_tuple(fixed_rank_extents,[&](auto const& J, auto const& n2){
+        for_each_tuple(fixed_rank_extents,[&](auto const& /*J*/, auto const& n2){
             using extents_type_2 = typename std::decay<decltype(n2)>::type;             
             using tensor_type_2 = ublas::fixed_rank_tensor<value_type, extents_type_2::_size, layout_type>;
             auto b  = tensor_type_2(n2, value_type(1));

--- a/test/tensor/utility.hpp
+++ b/test/tensor/utility.hpp
@@ -50,19 +50,25 @@ using zip = zip_helper<std::tuple<>,types...>;
 
 template<size_t I, class CallBack, class...Ts>
 struct for_each_tuple_impl{
-    auto operator()(std::tuple<Ts...>& t, CallBack call_back){
-        call_back(I,std::get<I>(t));
-        if constexpr(sizeof...(Ts) - 1 > I){
-            for_each_tuple_impl<I + 1,CallBack,Ts...> it;
-            it(t,call_back);
-        }
-    }
+  static_assert(sizeof...(Ts) > I, "Static Assert in boost::numeric::ublas::detail::for_each_tuple");
+  auto operator()(std::tuple<Ts...>& t, CallBack call_back)
+  {
+      call_back(I,std::get<I>(t));
+      if constexpr(sizeof...(Ts) - 1 > I){
+          for_each_tuple_impl<I + 1,CallBack,Ts...> it;
+          it(t,call_back);
+      }
+  }
 };
 
 template<class CallBack, class... Ts>
 auto for_each_tuple(std::tuple<Ts...>& t, CallBack call_back){
-    for_each_tuple_impl<0,CallBack,Ts...> f;
-    f(t,call_back);
+  if constexpr (std::tuple_size_v<std::tuple<Ts...>> == 0u )
+    return;
+
+  for_each_tuple_impl<0,CallBack,Ts...> f;
+  f(t,call_back);
+
 }
 
 


### PR DESCRIPTION
Using `valgrind` there were invalid reads in `test_static_functions.cpp` coming from line 158.
There are small bug fixes involved.
Many changes are due to formatting.