### PR TITLE
Disable branch coverage

### DIFF
--- a/.ci/report_coverage.sh
+++ b/.ci/report_coverage.sh
@@ -1,10 +1,10 @@
 #! /bin/bash -e
 
 sudo apt-get install lcov
-lcov --rc lcov_branch_coverage=1 --directory $BOOST_ROOT --capture --output-file coverage.info 
+lcov --directory $BOOST_ROOT --capture --output-file coverage.info 
 
 # Remove all unwanted coverages libs. 
 # Boost.uBLAS depends uses many internal boost libs, we don't want them to be in coverage. 
 
-lcov --rc lcov_branch_coverage=1 --extract coverage.info "*/boost/numeric/ublas/tensor/*" "*/libs/numeric/ublas/tensor/*" --output-file coverage.info
-lcov --rc lcov_branch_coverage=1 --list coverage.info
+lcov --extract coverage.info "*/boost/numeric/ublas/tensor/*" "*/libs/numeric/ublas/tensor/*" --output-file coverage.info
+lcov --list coverage.info


### PR DESCRIPTION
Branch coverage needs to be explicitly enabled and is not the defaault configuration of `lcov` . It is better to disable branch coverage because then we will have only 2 things for each line in coverage report. Either a line is hit or a miss. This is even the default behaviour of `llvm-cov` for coverage reporting. For reference check [this](https://codecov.io/gh/tzlaine/text/tree/master/boost/text) Zach's Library for Unicode which recently got partially approved for Boost. This library also uses default coverage settings. 

**After this commit coverage will be 95%**