### PR TITLE
Fix all clang-tidy warnings & Improve Review action

### DIFF
--- a/.github/workflows/clangtidy_check.yml
+++ b/.github/workflows/clangtidy_check.yml
@@ -4,7 +4,7 @@
 
 name: Clang tidy checks
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   check:

--- a/.github/workflows/clangtidy_review.yml
+++ b/.github/workflows/clangtidy_review.yml
@@ -10,9 +10,9 @@ jobs:
   check:
     name: Clang tidy Review 
     runs-on: ubuntu-20.04
+    if: ${{ github.repository }} == "boostorg/ublas"
     steps:
-      - uses: actions/checkout@v2
-        
+      - uses: actions/checkout@v2  
       - name: "Install dependencies"
         run: |
           sudo apt-get install -y clang-10 clang-tidy-10 

--- a/.github/workflows/clangtidy_review.yml
+++ b/.github/workflows/clangtidy_review.yml
@@ -10,7 +10,7 @@ jobs:
   check:
     name: Clang tidy Review 
     runs-on: ubuntu-20.04
-    if: ${{ github.event.pull_request.head.repo.fork }} == false
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v2  
       - name: "Install dependencies"

--- a/.github/workflows/clangtidy_review.yml
+++ b/.github/workflows/clangtidy_review.yml
@@ -10,7 +10,7 @@ jobs:
   check:
     name: Clang tidy Review 
     runs-on: ubuntu-20.04
-    if: ${{ github.repository }} == "boostorg/ublas"
+    if: ${{ github.event.pull_request.head.repo.fork }} == false
     steps:
       - uses: actions/checkout@v2  
       - name: "Install dependencies"

--- a/examples/tensor/.clang-tidy
+++ b/examples/tensor/.clang-tidy
@@ -1,6 +1,6 @@
 ---
-Checks:                 '-*,modernize-*,cppcoreguidelines-*,openmp-*,bugprone-*,performance-*,portability-*,readability-*,-modernize-use-trailing-return-type,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-readability-uppercase-literal-suffix,-readability-braces-around-statements,-cppcoreguidelines-avoid-magic-numbers,-readability-magic-numbers'
-WarningsAsErrors:       '-*,modernize-*,cppcoreguidelines-*,openmp-*,bugprone-*,performance-*,portability-*,readability-*,-modernize-use-trailing-return-type,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-readability-uppercase-literal-suffix,-readability-braces-around-statements,-cppcoreguidelines-avoid-magic-numbers,-readability-magic-numbers'
+Checks:                 '-*,modernize-*,cppcoreguidelines-*,openmp-*,bugprone-*,performance-*,portability-*,readability-*,-modernize-use-trailing-return-type,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-readability-uppercase-literal-suffix,-readability-braces-around-statements,-cppcoreguidelines-avoid-magic-numbers,-readability-magic-numbers,-bugprone-exception-escape'
+WarningsAsErrors:       '-*,modernize-*,cppcoreguidelines-*,openmp-*,bugprone-*,performance-*,portability-*,readability-*,-modernize-use-trailing-return-type,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-readability-uppercase-literal-suffix,-readability-braces-around-statements,-cppcoreguidelines-avoid-magic-numbers,-readability-magic-numbers,-bugprone-exception-escape'
 HeaderFilterRegex:      'boost\/numeric\/ublas\/tensor\/.*'
 AnalyzeTemporaryDtors:  false
 FormatStyle:            file

--- a/include/boost/numeric/ublas/tensor/detail/extents_functions.hpp
+++ b/include/boost/numeric/ublas/tensor/detail/extents_functions.hpp
@@ -229,8 +229,8 @@ constexpr bool is_vector(ExtentsType const &e) {
   auto equal_one = [](auto const &a) { return a == 1u; };
 
   if      (e.empty()) return false;
-  else if (e.size() == 1u) return e[0] > 1u;
-  else  return  std::any_of(e.begin(), e.begin() + 2, greater_one) &&
+  if (e.size() == 1u) return e[0] > 1u;
+  return  std::any_of(e.begin(), e.begin() + 2, greater_one) &&
                 std::any_of(e.begin(), e.begin() + 2, equal_one) &&
                 std::all_of(e.begin() + 2, e.end(), equal_one);
 
@@ -297,7 +297,7 @@ constexpr auto product(ExtentsType const &e) {
   static_assert(is_extents_v<ExtentsType>, "boost::numeric::ublas::product() : invalid type, type should be an extents");
   
   if ( e.empty() ) return 0u;
-  else return std::accumulate(e.begin(), e.end(), 1u, std::multiplies<>()) ;
+  return std::accumulate(e.begin(), e.end(), 1u, std::multiplies<>()) ;
 }
 
 

--- a/include/boost/numeric/ublas/tensor/functions.hpp
+++ b/include/boost/numeric/ublas/tensor/functions.hpp
@@ -392,8 +392,9 @@ namespace boost::numeric::ublas
             nc[r + i] = nb[phib1[i] - 1];
 
         // std::copy( phib.begin(), phib.end(), phib1.end()  );
-
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
         assert(phia1.size() == pa);
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
         assert(phib1.size() == pb);
 
         using c_extents_type = std::decay_t< decltype(nc) >;

--- a/include/boost/numeric/ublas/tensor/multiplication.hpp
+++ b/include/boost/numeric/ublas/tensor/multiplication.hpp
@@ -59,24 +59,28 @@ void ttt(SizeType const k,
 {
     if(k < r)
     {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
         assert(nc[k] == na[phia[k]-1]);
         for(size_t ic = 0u; ic < nc[k]; a += wa[phia[k]-1], c += wc[k], ++ic)
             ttt(k+1, r, s, q,  phia,phib,  c, nc, wc,   a, na, wa,   b, nb, wb);
     }
     else if(k < r+s)
     {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
         assert(nc[k] == nb[phib[k-r]-1]);
         for(size_t ic = 0u; ic < nc[k]; b += wb[phib[k-r]-1], c += wc[k], ++ic)
             ttt(k+1, r, s, q,  phia, phib,    c, nc, wc,   a, na, wa,   b, nb, wb);
     }
     else if(k < r+s+q-1)
     {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay) 
         assert(na[phia[k-s]-1] == nb[phib[k-r]-1]);
         for(size_t ia = 0u; ia < na[phia[k-s]-1]; a += wa[phia[k-s]-1], b += wb[phib[k-r]-1], ++ia)
             ttt(k+1, r, s, q,  phia, phib,  c, nc, wc,   a, na, wa,   b, nb, wb);
     }
     else
     {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
         assert(na[phia[k-s]-1] == nb[phib[k-r]-1]);
         for(size_t ia = 0u; ia < na[phia[k-s]-1]; a += wa[phia[k-s]-1], b += wb[phib[k-r]-1], ++ia)
             *c += *a * *b;
@@ -122,24 +126,28 @@ void ttt(SizeType const k,
 {
     if(k < r)
     {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
         assert(nc[k] == na[k]);
         for(size_t ic = 0u; ic < nc[k]; a += wa[k], c += wc[k], ++ic)
             ttt(k+1, r, s, q,  c, nc, wc,   a, na, wa,   b, nb, wb);
     }
     else if(k < r+s)
     {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
         assert(nc[k] == nb[k-r]);
         for(size_t ic = 0u; ic < nc[k]; b += wb[k-r], c += wc[k], ++ic)
             ttt(k+1, r, s, q,  c, nc, wc,   a, na, wa,   b, nb, wb);
     }
     else if(k < r+s+q-1)
     {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
         assert(na[k-s] == nb[k-r]);
         for(size_t ia = 0u; ia < na[k-s]; a += wa[k-s], b += wb[k-r], ++ia)
             ttt(k+1, r, s, q,  c, nc, wc,   a, na, wa,   b, nb, wb);
     }
     else
     {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
         assert(na[k-s] == nb[k-r]);
         for(size_t ia = 0u; ia < na[k-s]; a += wa[k-s], b += wb[k-r], ++ia)
             *c += *a * *b;
@@ -384,9 +392,11 @@ void mtm(PointerOut c, SizeType const*const nc, SizeType const*const wc,
 {
 
     // C(i,j) = A(i,k) * B(k,j)
-
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
     assert(nc[0] == na[0]);
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay) 
     assert(nc[1] == nb[1]);
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
     assert(na[1] == nb[0]);
 
     auto cj = c; auto bj = b;
@@ -543,18 +553,22 @@ void outer(SizeType const k,
 {
     if(k < r)
     {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
         assert(nc[k] == na[phia[k]-1]);
         for(size_t ic = 0u; ic < nc[k]; a += wa[phia[k]-1], c += wc[k], ++ic)
             outer(k+1, r, s,   phia,phib,  c, nc, wc,   a, na, wa,   b, nb, wb);
     }
     else if(k < r+s-1)
     {
+
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
         assert(nc[k] == nb[phib[k-r]-1]);
         for(size_t ic = 0u; ic < nc[k]; b += wb[phib[k-r]-1], c += wc[k], ++ic)
             outer(k+1, r, s, phia, phib,    c, nc, wc,   a, na, wa,   b, nb, wb);
     }
     else
     {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
         assert(nc[k] == nb[phib[k-r]-1]);
         for(size_t ic = 0u; ic < nc[k]; b += wb[phib[k-r]-1], c += wc[k], ++ic)
             *c = *a * *b;

--- a/include/boost/numeric/ublas/tensor/operators_arithmetic.hpp
+++ b/include/boost/numeric/ublas/tensor/operators_arithmetic.hpp
@@ -41,42 +41,152 @@ class vector_expression;
 }
 }
 
-#define FIRST_ORDER_OPERATOR_RIGHT(OP, EXPR_TYPE_L, EXPR_TYPE_R) \
-template<class T, class L, class R> \
-constexpr auto operator OP ( boost::numeric::ublas:: EXPR_TYPE_L <T,L> const& lhs, boost::numeric::ublas:: EXPR_TYPE_R <R> const& rhs) { \
-    return boost::numeric::ublas::detail::make_binary_tensor_expression<T> (lhs(), rhs(), \
-      [](auto const& l, auto const& r){ return l OP r; }); \
-} \
+template <class T, class L, class R>
+constexpr auto operator*(
+  boost ::numeric ::ublas ::detail ::tensor_expression<T, L> const& lhs,
+  boost ::numeric ::ublas ::vector_expression<R> const& rhs)
+{
+  return boost ::numeric ::ublas ::detail ::make_binary_tensor_expression<T>(
+    lhs(), rhs(), [](auto const& l, auto const& r) { return l * r; });
+}
 
-FIRST_ORDER_OPERATOR_RIGHT (*, detail:: tensor_expression , vector_expression)
-FIRST_ORDER_OPERATOR_RIGHT (+, detail:: tensor_expression , vector_expression)
-FIRST_ORDER_OPERATOR_RIGHT (-, detail:: tensor_expression , vector_expression)
-FIRST_ORDER_OPERATOR_RIGHT (/, detail:: tensor_expression , vector_expression)
+template <class T, class L, class R>
+constexpr auto operator+(
+  boost ::numeric ::ublas ::detail ::tensor_expression<T, L> const& lhs,
+  boost ::numeric ::ublas ::vector_expression<R> const& rhs)
+{
+  return boost ::numeric ::ublas ::detail ::make_binary_tensor_expression<T>(
+    lhs(), rhs(), [](auto const& l, auto const& r) { return l + r; });
+}
 
-FIRST_ORDER_OPERATOR_RIGHT (*, detail:: tensor_expression , matrix_expression)
-FIRST_ORDER_OPERATOR_RIGHT (+, detail:: tensor_expression , matrix_expression)
-FIRST_ORDER_OPERATOR_RIGHT (-, detail:: tensor_expression , matrix_expression)
-FIRST_ORDER_OPERATOR_RIGHT (/, detail:: tensor_expression , matrix_expression)
+template <class T, class L, class R>
+constexpr auto operator-(
+  boost ::numeric ::ublas ::detail ::tensor_expression<T, L> const& lhs,
+  boost ::numeric ::ublas ::vector_expression<R> const& rhs)
+{
+  return boost ::numeric ::ublas ::detail ::make_binary_tensor_expression<T>(
+    lhs(), rhs(), [](auto const& l, auto const& r) { return l - r; });
+}
+
+template <class T, class L, class R>
+constexpr auto operator/(
+  boost ::numeric ::ublas ::detail ::tensor_expression<T, L> const& lhs,
+  boost ::numeric ::ublas ::vector_expression<R> const& rhs)
+{
+  return boost ::numeric ::ublas ::detail ::make_binary_tensor_expression<T>(
+    lhs(), rhs(), [](auto const& l, auto const& r) { return l / r; });
+}
 
 
-#define FIRST_ORDER_OPERATOR_LEFT(OP, EXPR_TYPE_L, EXPR_TYPE_R) \
-template<class T, class L, class R> \
-constexpr auto operator OP ( boost::numeric::ublas:: EXPR_TYPE_L <L> const& lhs, boost::numeric::ublas:: EXPR_TYPE_R <T,R> const& rhs) { \
-    return boost::numeric::ublas::detail::make_binary_tensor_expression<T> (lhs(), rhs(), \
-      [](auto const& l, auto const& r){ return l OP r; }); \
-} \
+template <class T, class L, class R>
+constexpr auto operator*(
+  boost ::numeric ::ublas ::detail ::tensor_expression<T, L> const& lhs,
+  boost ::numeric ::ublas ::matrix_expression<R> const& rhs)
+{
+  return boost ::numeric ::ublas ::detail ::make_binary_tensor_expression<T>(
+    lhs(), rhs(), [](auto const& l, auto const& r) { return l * r; });
+}
 
-FIRST_ORDER_OPERATOR_LEFT (*, vector_expression, detail:: tensor_expression)
-FIRST_ORDER_OPERATOR_LEFT (+, vector_expression, detail:: tensor_expression)
-FIRST_ORDER_OPERATOR_LEFT (-, vector_expression, detail:: tensor_expression)
-FIRST_ORDER_OPERATOR_LEFT (/, vector_expression, detail:: tensor_expression)
+template <class T, class L, class R>
+constexpr auto operator+(
+  boost ::numeric ::ublas ::detail ::tensor_expression<T, L> const& lhs,
+  boost ::numeric ::ublas ::matrix_expression<R> const& rhs)
+{
+  return boost ::numeric ::ublas ::detail ::make_binary_tensor_expression<T>(
+    lhs(), rhs(), [](auto const& l, auto const& r) { return l + r; });
+}
 
-FIRST_ORDER_OPERATOR_LEFT (*, matrix_expression, detail:: tensor_expression)
-FIRST_ORDER_OPERATOR_LEFT (+, matrix_expression, detail:: tensor_expression)
-FIRST_ORDER_OPERATOR_LEFT (-, matrix_expression, detail:: tensor_expression)
-FIRST_ORDER_OPERATOR_LEFT (/, matrix_expression, detail:: tensor_expression)
+template <class T, class L, class R>
+constexpr auto operator-(
+  boost ::numeric ::ublas ::detail ::tensor_expression<T, L> const& lhs,
+  boost ::numeric ::ublas ::matrix_expression<R> const& rhs)
+{
+  return boost ::numeric ::ublas ::detail ::make_binary_tensor_expression<T>(
+    lhs(), rhs(), [](auto const& l, auto const& r) { return l - r; });
+}
+
+template <class T, class L, class R>
+constexpr auto operator/(
+  boost ::numeric ::ublas ::detail ::tensor_expression<T, L> const& lhs,
+  boost ::numeric ::ublas ::matrix_expression<R> const& rhs)
+{
+  return boost ::numeric ::ublas ::detail ::make_binary_tensor_expression<T>(
+    lhs(), rhs(), [](auto const& l, auto const& r) { return l / r; });
+}
 
 
+template <class T, class L, class R>
+constexpr auto operator*(
+  boost ::numeric ::ublas ::vector_expression<L> const& lhs,
+  boost ::numeric ::ublas ::detail ::tensor_expression<T, R> const& rhs)
+{
+  return boost ::numeric ::ublas ::detail ::make_binary_tensor_expression<T>(
+    lhs(), rhs(), [](auto const& l, auto const& r) { return l * r; });
+}
+
+template <class T, class L, class R>
+constexpr auto operator+(
+  boost ::numeric ::ublas ::vector_expression<L> const& lhs,
+  boost ::numeric ::ublas ::detail ::tensor_expression<T, R> const& rhs)
+{
+  return boost ::numeric ::ublas ::detail ::make_binary_tensor_expression<T>(
+    lhs(), rhs(), [](auto const& l, auto const& r) { return l + r; });
+}
+
+template <class T, class L, class R>
+constexpr auto operator-(
+  boost ::numeric ::ublas ::vector_expression<L> const& lhs,
+  boost ::numeric ::ublas ::detail ::tensor_expression<T, R> const& rhs)
+{
+  return boost ::numeric ::ublas ::detail ::make_binary_tensor_expression<T>(
+    lhs(), rhs(), [](auto const& l, auto const& r) { return l - r; });
+}
+
+template <class T, class L, class R>
+constexpr auto operator/(
+  boost ::numeric ::ublas ::vector_expression<L> const& lhs,
+  boost ::numeric ::ublas ::detail ::tensor_expression<T, R> const& rhs)
+{
+  return boost ::numeric ::ublas ::detail ::make_binary_tensor_expression<T>(
+    lhs(), rhs(), [](auto const& l, auto const& r) { return l / r; });
+}
+
+
+template <class T, class L, class R>
+constexpr auto operator*(
+  boost ::numeric ::ublas ::matrix_expression<L> const& lhs,
+  boost ::numeric ::ublas ::detail ::tensor_expression<T, R> const& rhs)
+{
+  return boost ::numeric ::ublas ::detail ::make_binary_tensor_expression<T>(
+    lhs(), rhs(), [](auto const& l, auto const& r) { return l * r; });
+}
+
+template <class T, class L, class R>
+constexpr auto operator+(
+  boost ::numeric ::ublas ::matrix_expression<L> const& lhs,
+  boost ::numeric ::ublas ::detail ::tensor_expression<T, R> const& rhs)
+{
+  return boost ::numeric ::ublas ::detail ::make_binary_tensor_expression<T>(
+    lhs(), rhs(), [](auto const& l, auto const& r) { return l + r; });
+}
+
+template <class T, class L, class R>
+constexpr auto operator-(
+  boost ::numeric ::ublas ::matrix_expression<L> const& lhs,
+  boost ::numeric ::ublas ::detail ::tensor_expression<T, R> const& rhs)
+{
+  return boost ::numeric ::ublas ::detail ::make_binary_tensor_expression<T>(
+    lhs(), rhs(), [](auto const& l, auto const& r) { return l - r; });
+}
+
+template <class T, class L, class R>
+constexpr auto operator/(
+  boost ::numeric ::ublas ::matrix_expression<L> const& lhs,
+  boost ::numeric ::ublas ::detail ::tensor_expression<T, R> const& rhs)
+{
+  return boost ::numeric ::ublas ::detail ::make_binary_tensor_expression<T>(
+    lhs(), rhs(), [](auto const& l, auto const& r) { return l / r; });
+}
 
 
 template<class T1, class T2, class L, class R>


### PR DESCRIPTION
This PR fixes all clang-tidy warnings so that all clang-tidy all clang-tidy checks will pass.

It basically has the following changes:
1. Remove `return after else` warnings.
2. Expand macros in `operator_arithematics.hpp`
3. Suppress false warnings from `assert()` in the codebase.
4. Suppress `bug-exception-escape` for tensor examples.