### PR TITLE
Disable openCL for appveyor:

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,21 +25,7 @@ environment:
       CXXSTD: 11
 
 install:
-  - cd "C:\Tools\vcpkg"
-  - git pull
-  - .\bootstrap-vcpkg.bat
   - cd %appveyor_build_folder%
-  # Install OpenCL runtime (driver) for Intel / Xeon package
-  - appveyor DownloadFile "http://registrationcenter-download.intel.com/akdlm/irc_nas/9022/opencl_runtime_16.1.1_x64_setup.msi"
-  - start /wait msiexec /i opencl_runtime_16.1.1_x64_setup.msi /qn  /l*v msiexec2.log
-  # FIXME: To be removed https://help.appveyor.com/discussions/problems/13000-cmake_toolchain_filevcpkgcmake-conflicts-with-cmake-native-findboostcmake"
-  - ps: 'Write-Host "Installing latest vcpkg.cmake module" -ForegroundColor Magenta'
-  - appveyor DownloadFile https://raw.githubusercontent.com/Microsoft/vcpkg/master/scripts/buildsystems/vcpkg.cmake -FileName "c:\tools\vcpkg\scripts\buildsystems\vcpkg.cmake"
-  - set "TRIPLET=x64-windows"
-  - vcpkg --triplet %TRIPLET% install opencl clblas
-  - set PATH=C:\Tools\vcpkg\installed\%TRIPLET%\bin;%PATH%
-  - set VCPKG_I=C:\Tools\vcpkg\installed\%TRIPLET%\include
-  - set VCPKG_L=C:\Tools\vcpkg\installed\%TRIPLET%\lib
   - set BOOST_BRANCH=develop
   - if "%APPVEYOR_REPO_BRANCH%" == "master" set BOOST_BRANCH=master
   - cd ..
@@ -57,11 +43,7 @@ install:
       @'
       import os regex toolset ;
       local toolset = [ regex.split [ os.environ TOOLSET ] "-" ] ;
-      local vcpkg_i = [ os.environ VCPKG_I ] ;
-      local vcpkg_l = [ os.environ VCPKG_L ] ;
       using $(toolset[1]) : $(toolset[2-]:J="-") :  ;
-      using opencl : : <include>$(vcpkg_i) <search>$(vcpkg_l) ;
-      using clblas : : <include>$(vcpkg_i) <search>$(vcpkg_l) ;
       '@ | sc "$env:USERPROFILE/user-config.jam"
   - cmd /c bootstrap
   - b2 -j3 headers


### PR DESCRIPTION
openCL tests on Appveyor are failing due to some vcpkg issue. 

As per my mentor @bassoy request, I am removing the openCL tests from the appveyor. The mentioned reason for this removal is:

- We will soon migrate to openMP with new tensor design
- openCL usage is not documented and hence very likely not being used.