### PR TITLE
Hot fix for github action YAML files

### DIFF
--- a/.github/workflows/address_san.yml
+++ b/.github/workflows/address_san.yml
@@ -47,7 +47,8 @@ jobs:
          ./bootstrap.sh
          ./b2 -j 8 headers
         
-         echo ::set-env name=BOOST_ROOT::${PWD}
+         #echo ::set-env name=BOOST_ROOT::${PWD}
+         echo "BOOST_ROOT=${PWD}" >> $GITHUB_ENV
         
       - name: Prepare Build
         run: |

--- a/.github/workflows/apple_clang.yml
+++ b/.github/workflows/apple_clang.yml
@@ -44,7 +44,8 @@ jobs:
         ./bootstrap.sh
         ./b2 -j 8 headers
         
-        echo ::set-env name=BOOST_ROOT::${PWD}
+        #echo ::set-env name=BOOST_ROOT::${PWD}
+        echo "BOOST_ROOT=${PWD}" >> ${GITHUB_ENV}
         
     - name: Prepare Build
       run: |

--- a/.github/workflows/linux_clang.yml
+++ b/.github/workflows/linux_clang.yml
@@ -68,7 +68,8 @@ jobs:
         ./bootstrap.sh
         ./b2 -j 8 headers
         
-        echo ::set-env name=BOOST_ROOT::${PWD}
+        #echo ::set-env name=BOOST_ROOT::${PWD}
+        echo "BOOST_ROOT=${PWD}" >> ${GITHUB_ENV}
         
     - name: Prepare Build
       run: |

--- a/.github/workflows/linux_gcc.yml
+++ b/.github/workflows/linux_gcc.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Mohammad Ashar Khan
+# Copyright (c) 2020 Mohammad Ashar Khan, Cem Bassoy
 # Distributed under Boost Software License, Version 1.0
 # (See accompanying file LICENSE_1_0.txt or copy at http://boost.org/LICENSE_1_0.txt)
 
@@ -60,7 +60,8 @@ jobs:
          ./bootstrap.sh
          ./b2 -j 8 headers
         
-         echo ::set-env name=BOOST_ROOT::${PWD}
+         #echo ::set-env name=BOOST_ROOT::${PWD}
+         echo "BOOST_ROOT=${PWD}" >> $GITHUB_ENV
         
       - name: Prepare Build
         run: |

--- a/.github/workflows/thread_san.yml
+++ b/.github/workflows/thread_san.yml
@@ -47,7 +47,8 @@ jobs:
          ./bootstrap.sh
          ./b2 -j 8 headers
         
-         echo ::set-env name=BOOST_ROOT::${PWD}
+         #echo ::set-env name=BOOST_ROOT::${PWD}
+         echo "BOOST_ROOT=${PWD}" >> ${GITHUB_ENV}
         
       - name: Prepare Build
         run: |

--- a/.github/workflows/ub_san.yml
+++ b/.github/workflows/ub_san.yml
@@ -47,7 +47,8 @@ jobs:
          ./bootstrap.sh
          ./b2 -j 8 headers
         
-         echo ::set-env name=BOOST_ROOT::${PWD}
+         #echo ::set-env name=BOOST_ROOT::${PWD}
+         echo "BOOST_ROOT=${PWD}" >> ${GITHUB_ENV}
         
       - name: Prepare Build
         run: |

--- a/.github/workflows/windows_msvc.yml
+++ b/.github/workflows/windows_msvc.yml
@@ -14,29 +14,29 @@ on:
       - 'doc/**'
 jobs:
   build:
-     name: "${{matrix.config.version}} -std=c++${{matrix.config.cxxstd}}"
+     name: "windows=${{matrix.config.os}} msvc=${{matrix.config.version}} std=c++${{matrix.config.cxxstd}}"
      runs-on: ${{matrix.config.os}}
      strategy:
        fail-fast: false
        matrix:
          config: 
            - {os: windows-2016, toolset: msvc, version: 14.16, cxxstd: 11} 
-           - {os: windows-2019, toolset: msvc, version: 14.27, cxxstd: 11}
-           - {os: windows-2019, toolset: msvc, version: 14.27, cxxstd: 17}
-           - {os: windows-2019, toolset: msvc, version: 14.27, cxxstd: latest}
+           - {os: windows-2019, toolset: msvc, version: 14.28, cxxstd: 11}
+           - {os: windows-2019, toolset: msvc, version: 14.28, cxxstd: 17}
+           - {os: windows-2019, toolset: msvc, version: 14.28, cxxstd: latest}
              
      steps:
       - uses: actions/checkout@v2
         
       - name: Enable Developer Command Prompt
-        uses: ilammy/msvc-dev-cmd@v1.3.0
+        uses: ilammy/msvc-dev-cmd@v1
         with:
           toolset: ${{matrix.config.version}}
       
       - name: Setup BOOST_ROOT
-        shell: cmd
+        shell: powershell
         run: |
-          cd %GITHUB_WORKSPACE%
+          cd $env:GITHUB_WORKSPACE
           cd ..
           git clone -b master --depth 1 https://github.com/boostorg/boost.git boost-root
           cd boost-root
@@ -44,12 +44,13 @@ jobs:
           git submodule update --init --depth=1 libs/config
           git submodule update --init --depth=1 tools/boostdep
           
-          xcopy /s /e /q %GITHUB_WORKSPACE% libs\numeric\ublas
+          xcopy /s /e /q $env:GITHUB_WORKSPACE libs\numeric\ublas
           
           python tools/boostdep/depinst/depinst.py -g " --depth=1" -I benchmarks numeric/ublas
           
-          echo ::set-env name=BOOST_ROOT::%cd%
-          echo ::set-env name=TOOLSET::${{matrix.config.toolset}}-${{matrix.config.version}}    
+        
+          echo "BOOST_ROOT=$pwd" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "TOOLSET=${{matrix.config.toolset}}-${{matrix.config.version}}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           
       - name: Prepare BOOST_ROOT
         shell: powershell


### PR DESCRIPTION
This is a hot fix for github action YAML files. 

Fixed the deprecated set-env commands, see [github blog](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/).