### PR TITLE
Clang tidy: include check `google-readability-braces-around-statements`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,13 @@
 ---
-Checks: '-*,clang-*,bugprone-*,cppcoreguidelines-*,google-*,hicpp-*,modernize-*,performance-*,readability-*,portability-*,
--modernize-use-trailing-return-type, -readability-uppercase-literal-suffix, -readability-braces-around-statements, -hicpp-uppercase-literal-suffix, -hicpp-braces-around-statements, -hicpp-no-array-decay, -cppcoreguidelines-pro-bounds-constant-array-index, -cppcoreguidelines-pro-bounds-pointer-arithmetic, -cppcoreguidelines-pro-bounds-array-to-pointer-decay, -readability-avoid-const-params-in-decls, -google-readability-braces-around-statements,-google-explicit-constructor,-hicpp-vararg,-cppcoreguidelines-pro-type-vararg, -cppcoreguidelines-avoid-non-const-global-variables, -google-readability-todo, -cppcoreguidelines-pro-type-member-init, -hicpp-member-init, -cppcoreguidelines-special-member-functions, -hicpp-special-member-functions'
+Checks: '-*,clang-*,bugprone-*,cppcoreguidelines-*,google-*,hicpp-*,modernize-*,performance-*,
+readability-*,portability-*, -modernize-use-trailing-return-type, -readability-uppercase-literal-suffix, 
+-readability-braces-around-statements, -hicpp-uppercase-literal-suffix, -hicpp-braces-around-statements, 
+-hicpp-no-array-decay, -cppcoreguidelines-pro-bounds-constant-array-index,
+-cppcoreguidelines-pro-bounds-pointer-arithmetic, -cppcoreguidelines-pro-bounds-array-to-pointer-decay, 
+-readability-avoid-const-params-in-decls,-google-explicit-constructor, -hicpp-vararg,-cppcoreguidelines-pro-type-vararg,
+-cppcoreguidelines-avoid-non-const-global-variables, -google-readability-todo,
+-cppcoreguidelines-pro-type-member-init, -hicpp-member-init, -cppcoreguidelines-special-member-functions,
+-hicpp-special-member-functions'
 HeaderFilterRegex:      'boost\/numeric\/ublas\/tensor\/.*'
 AnalyzeTemporaryDtors:  false
 FormatStyle:            file

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,13 +1,12 @@
 ---
 Checks: '-*,clang-*,bugprone-*,cppcoreguidelines-*,google-*,hicpp-*,modernize-*,performance-*,
-readability-*,portability-*, -modernize-use-trailing-return-type, -readability-uppercase-literal-suffix, 
--readability-braces-around-statements, -hicpp-uppercase-literal-suffix, -hicpp-braces-around-statements, 
--hicpp-no-array-decay, -cppcoreguidelines-pro-bounds-constant-array-index,
--cppcoreguidelines-pro-bounds-pointer-arithmetic, -cppcoreguidelines-pro-bounds-array-to-pointer-decay, 
--readability-avoid-const-params-in-decls,-google-explicit-constructor, -hicpp-vararg,-cppcoreguidelines-pro-type-vararg,
--cppcoreguidelines-avoid-non-const-global-variables, -google-readability-todo,
--cppcoreguidelines-pro-type-member-init, -hicpp-member-init, -cppcoreguidelines-special-member-functions,
--hicpp-special-member-functions'
+readability-*,portability-*, -modernize-use-trailing-return-type, -readability-uppercase-literal-suffix,
+-hicpp-uppercase-literal-suffix, -hicpp-braces-around-statements, -hicpp-no-array-decay,
+-cppcoreguidelines-pro-bounds-constant-array-index, -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+-cppcoreguidelines-pro-bounds-array-to-pointer-decay, -readability-avoid-const-params-in-decls,
+-google-explicit-constructor, -hicpp-vararg,-cppcoreguidelines-pro-type-vararg,
+-cppcoreguidelines-avoid-non-const-global-variables, -google-readability-todo, -cppcoreguidelines-pro-type-member-init,
+-hicpp-member-init, -cppcoreguidelines-special-member-functions, -hicpp-special-member-functions'
 HeaderFilterRegex:      'boost\/numeric\/ublas\/tensor\/.*'
 AnalyzeTemporaryDtors:  false
 FormatStyle:            file

--- a/examples/tensor/access_tensor.cpp
+++ b/examples/tensor/access_tensor.cpp
@@ -36,9 +36,10 @@ int main()
     // initializes the tensor with increasing values along the first-index
     // using a single index.
     auto vf = 1.0f;
-    for(auto i = 0u; i < A.size(); ++i, vf += 1.0f)
+    for(auto i = 0u; i < A.size(); ++i, vf += 1.0f){
       A[i] = vf;
-
+    }
+    
     // formatted output
     std::cout << "% --------------------------- " << std::endl;
     std::cout << "% --------------------------- " << std::endl << std::endl;
@@ -68,8 +69,9 @@ int main()
     // initializes the tensor with increasing values along the last-index
     // using a single-index
     auto vc = value(0,0);
-    for(auto i = 0u; i < B.size(); ++i, vc += value(1,1))
+    for(auto i = 0u; i < B.size(); ++i, vc += value(1,1)){
       B[i] = vc;
+    }
 
     // formatted output
     std::cout << "% --------------------------- " << std::endl;
@@ -79,12 +81,16 @@ int main()
 
     auto C = tensor(B.extents());
     // computes the complex conjugate of elements of B
-    // using multi-index notation.
-    for(auto i = 0u; i < B.size(0); ++i)
-      for(auto j = 0u; j < B.size(1); ++j)
-        for(auto k = 0u; k < B.size(2); ++k)
-          for(auto l = 0u; l < B.size(3); ++l)
+    // using multi-index notation. 
+    for(auto i = 0u; i < B.size(0); ++i){
+      for(auto j = 0u; j < B.size(1); ++j){
+        for(auto k = 0u; k < B.size(2); ++k){
+          for(auto l = 0u; l < B.size(3); ++l){
             C.at(i,j,k,l) = std::conj(B.at(i,j,k,l));
+          }
+        }
+      }
+    }
 
     std::cout << "% --------------------------- " << std::endl;
     std::cout << "% --------------------------- " << std::endl << std::endl;

--- a/include/boost/numeric/ublas/tensor/algorithms.hpp
+++ b/include/boost/numeric/ublas/tensor/algorithms.hpp
@@ -100,29 +100,36 @@ constexpr void transform(SizeType const p,
 {
   static_assert( std::is_pointer<PointerOut>::value & std::is_pointer<PointerIn>::value,
                 "Static error in boost::numeric::ublas::transform: Argument types for pointers are not pointer types.");
-  if( p == 0 )
+  if( p == 0 ){
     return;
+  }
 
-  if(c == nullptr || a == nullptr)
+  if(c == nullptr || a == nullptr){
     throw std::runtime_error("Error in boost::numeric::ublas::transform: Pointers shall not be null pointers.");
+  }
 
-  if(wc == nullptr || wa == nullptr)
+  if(wc == nullptr || wa == nullptr){
     throw std::runtime_error("Error in boost::numeric::ublas::transform: Pointers shall not be null pointers.");
+  }
 
-  if(n == nullptr)
+  if(n == nullptr){
     throw std::runtime_error("Error in boost::numeric::ublas::transform: Pointers shall not be null pointers.");
-
+  }
 
   std::function<void(SizeType r, PointerOut c, PointerIn a)> lambda;
 
   lambda = [&lambda, n, wc, wa, op](SizeType r, PointerOut c, PointerIn a)
   {
-    if(r > 0)
-      for(auto d = 0u; d < n[r]; c += wc[r], a += wa[r], ++d)
+    if(r > 0){
+      for(auto d = 0u; d < n[r]; c += wc[r], a += wa[r], ++d){
         lambda(r-1, c, a);
-    else
-      for(auto d = 0u; d < n[0]; c += wc[0], a += wa[0], ++d)
+      }
+    }
+    else{
+      for(auto d = 0u; d < n[0]; c += wc[0], a += wa[0], ++d){
         *c = op(*a);
+      }
+    }
   };
 
   lambda( p-1, c, a );
@@ -149,29 +156,36 @@ constexpr ValueType accumulate(SizeType const p, SizeType const*const n,
   static_assert(std::is_pointer<PointerIn>::value,
                 "Static error in boost::numeric::ublas::transform: Argument types for pointers are not pointer types.");
 
-  if( p == 0 )
+  if( p == 0 ){
     return k;
+  }
 
-  if(a == nullptr)
+  if(a == nullptr){
     throw std::runtime_error("Error in boost::numeric::ublas::transform: Pointers shall not be null pointers.");
+  }
 
-  if(w == nullptr)
+  if(w == nullptr){
     throw std::runtime_error("Error in boost::numeric::ublas::transform: Pointers shall not be null pointers.");
+  }
 
-  if(n == nullptr)
+  if(n == nullptr){
     throw std::runtime_error("Error in boost::numeric::ublas::transform: Pointers shall not be null pointers.");
-
+  }
 
   std::function<ValueType(SizeType r, PointerIn a, ValueType k)> lambda;
 
   lambda = [&lambda, n, w](SizeType r, PointerIn a, ValueType k)
   {
-    if(r > 0u)
-      for(auto d = 0u; d < n[r]; a += w[r], ++d)
+    if(r > 0u){
+      for(auto d = 0u; d < n[r]; a += w[r], ++d){
         k = lambda(r-1, a, k);
-    else
-      for(auto d = 0u; d < n[0]; a += w[0], ++d)
+      }
+    }
+    else{
+      for(auto d = 0u; d < n[0]; a += w[0], ++d){
         k += *a;
+      }
+    }
     return k;
   };
 
@@ -200,29 +214,37 @@ constexpr ValueType accumulate(SizeType const p, SizeType const*const n,
                 "Static error in boost::numeric::ublas::transform: Argument types for pointers are not pointer types.");
 
 
-  if( p == 0 )
+  if( p == 0 ){
     return k;
+  }
 
-  if(a == nullptr)
+  if(a == nullptr){
     throw std::runtime_error("Error in boost::numeric::ublas::transform: Pointers shall not be null pointers.");
+  }
 
-  if(w == nullptr)
+  if(w == nullptr){
     throw std::runtime_error("Error in boost::numeric::ublas::transform: Pointers shall not be null pointers.");
+  }
 
-  if(n == nullptr)
+  if(n == nullptr){
     throw std::runtime_error("Error in boost::numeric::ublas::transform: Pointers shall not be null pointers.");
+  }
 
 
   std::function<ValueType(SizeType r, PointerIn a, ValueType k)> lambda;
 
   lambda = [&lambda, n, w, op](SizeType r, PointerIn a, ValueType k)
   {
-    if(r > 0u)
-      for(auto d = 0u; d < n[r]; a += w[r], ++d)
+    if(r > 0u){
+      for(auto d = 0u; d < n[r]; a += w[r], ++d){
         k = lambda(r-1, a, k);
-    else
-      for(auto d = 0u; d < n[0]; a += w[0], ++d)
+      }
+    }
+    else{
+      for(auto d = 0u; d < n[0]; a += w[0], ++d){
         k = op ( k, *a );
+      }
+    }
     return k;
   };
 
@@ -253,35 +275,44 @@ constexpr void trans( SizeType const p,  SizeType const*const na, SizeType const
   static_assert( std::is_pointer<PointerOut>::value & std::is_pointer<PointerIn>::value,
                 "Static error in boost::numeric::ublas::trans: Argument types for pointers are not pointer types.");
 
-  if( p < 2)
+  if( p < 2){
     return;
+  }
 
-  if(c == nullptr || a == nullptr)
+  if(c == nullptr || a == nullptr){
     throw std::runtime_error("Error in boost::numeric::ublas::trans: Pointers shall not be null pointers.");
+  }
 
-  if(na == nullptr)
+  if(na == nullptr){
     throw std::runtime_error("Error in boost::numeric::ublas::trans: Pointers shall not be null.");
+  }
 
-  if(wc == nullptr || wa == nullptr)
+  if(wc == nullptr || wa == nullptr){
     throw std::runtime_error("Error in boost::numeric::ublas::trans: Pointers shall not be null pointers.");
+  }
 
-  if(na == nullptr)
+  if(na == nullptr){
     throw std::runtime_error("Error in boost::numeric::ublas::trans: Pointers shall not be null pointers.");
+  }
 
-  if(pi == nullptr)
+  if(pi == nullptr){
     throw std::runtime_error("Error in boost::numeric::ublas::trans: Pointers shall not be null pointers.");
-
+  }
 
   std::function<void(SizeType r, PointerOut c, PointerIn a)> lambda;
 
   lambda = [&lambda, na, wc, wa, pi](SizeType r, PointerOut c, PointerIn a)
   {
-    if(r > 0)
-      for(auto d = 0u; d < na[r]; c += wc[pi[r]-1], a += wa[r], ++d)
+    if(r > 0){
+      for(auto d = 0u; d < na[r]; c += wc[pi[r]-1], a += wa[r], ++d){
         lambda(r-1, c, a);
-    else
-      for(auto d = 0u; d < na[0]; c += wc[pi[0]-1], a += wa[0], ++d)
+      }
+    }
+    else{
+      for(auto d = 0u; d < na[0]; c += wc[pi[0]-1], a += wa[0], ++d){
         *c = *a;
+      }
+    }
   };
 
   lambda( p-1, c, a );
@@ -331,12 +362,16 @@ constexpr void trans(SizeType const p,
 
   lambda = [&lambda, na, wc, wa, pi](SizeType r, std::complex<ValueType>* c, std::complex<ValueType>* a)
   {
-    if(r > 0)
-      for(auto d = 0u; d < na[r]; c += wc[pi[r]-1], a += wa[r], ++d)
+    if(r > 0){
+      for(auto d = 0u; d < na[r]; c += wc[pi[r]-1], a += wa[r], ++d){
         lambda(r-1, c, a);
-    else
-      for(auto d = 0u; d < na[0]; c += wc[pi[0]-1], a += wa[0], ++d)
+      }
+    }
+    else{
+      for(auto d = 0u; d < na[0]; c += wc[pi[0]-1], a += wa[0], ++d){
         *c = std::conj(*a);
+      }
+    }
   };
 
   lambda( p-1, c, a );

--- a/include/boost/numeric/ublas/tensor/expression_evaluation.hpp
+++ b/include/boost/numeric/ublas/tensor/expression_evaluation.hpp
@@ -96,10 +96,12 @@ constexpr auto& retrieve_extents(tensor_expression<T,D> const& expr)
 
 	auto const& cast_expr = static_cast<D const&>(expr);
 
-	if constexpr ( std::is_same<T,D>::value )
-	    return cast_expr.extents();
-	else
-	return retrieve_extents(cast_expr);
+	if constexpr ( std::is_same<T,D>::value ) {
+		return cast_expr.extents();
+	}
+	else {
+		return retrieve_extents(cast_expr);
+	}
 }
 
 // Disable warning for unreachable code for MSVC compiler
@@ -120,17 +122,19 @@ constexpr auto& retrieve_extents(binary_tensor_expression<T,EL,ER,OP> const& exp
 	static_assert(detail::has_tensor_types<T,binary_tensor_expression<T,EL,ER,OP>>::value,
 	              "Error in boost::numeric::ublas::detail::retrieve_extents: Expression to evaluate should contain tensors.");
 
-	if constexpr ( std::is_same<T,EL>::value )
-	    return expr.el.extents();
+	if constexpr ( std::is_same<T,EL>::value ) {
+		return expr.el.extents();
+	}
 
-	if constexpr ( std::is_same<T,ER>::value )
-	    return expr.er.extents();
-
-	else if constexpr ( detail::has_tensor_types<T,EL>::value )
-	    return retrieve_extents(expr.el);
-
-	else if constexpr ( detail::has_tensor_types<T,ER>::value  )
-	    return retrieve_extents(expr.er);
+	if constexpr ( std::is_same<T,ER>::value ) {
+		return expr.er.extents();
+	}
+	else if constexpr ( detail::has_tensor_types<T,EL>::value ) {
+		return retrieve_extents(expr.el);
+	} 
+	else if constexpr ( detail::has_tensor_types<T,ER>::value ) {
+		return retrieve_extents(expr.er);
+	}
 }
 
 #ifdef _MSC_VER
@@ -151,11 +155,12 @@ constexpr auto& retrieve_extents(unary_tensor_expression<T,E,OP> const& expr)
 	static_assert(detail::has_tensor_types<T,unary_tensor_expression<T,E,OP>>::value,
 	              "Error in boost::numeric::ublas::detail::retrieve_extents: Expression to evaluate should contain tensors.");
 
-	if constexpr ( std::is_same<T,E>::value )
-	    return expr.e.extents();
-
-	else if constexpr ( detail::has_tensor_types<T,E>::value  )
-	    return retrieve_extents(expr.e);
+	if constexpr ( std::is_same<T,E>::value ) {
+		return expr.e.extents();
+	}
+	else if constexpr ( detail::has_tensor_types<T,E>::value  ) {
+		return retrieve_extents(expr.e);
+	}
 }
 
 } // namespace boost::numeric::ublas::detail
@@ -169,7 +174,7 @@ template<class EN, std::size_t ... es>
 [[nodiscard]] inline
   constexpr auto all_extents_equal(tensor_core<EN> const& t, extents<es...> const& e)
 {
-  return ::operator==(e,t.extents());
+	return ::operator==(e,t.extents());
 }
 
 template<class T, class D, std::size_t ... es>
@@ -182,16 +187,20 @@ constexpr auto all_extents_equal(tensor_expression<T,D> const& expr, extents<es.
 
 	auto const& cast_expr = static_cast<D const&>(expr);
 
-  using ::operator==;
-  using ::operator!=;
+	using ::operator==;
+	using ::operator!=;
 
-	if constexpr ( std::is_same<T,D>::value )
-      if( e != cast_expr.extents() )
-	    return false;
+	if constexpr ( std::is_same<T,D>::value ) {
+		if ( e != cast_expr.extents() ) {
+			return false;
+		}
+	}
 
-	if constexpr ( detail::has_tensor_types<T,D>::value )
-      if ( !all_extents_equal(cast_expr, e))
-	    return false;
+	if constexpr ( detail::has_tensor_types<T,D>::value ) {
+		if ( !all_extents_equal(cast_expr, e)) {
+			return false;
+		}
+	}
 
 	return true;
 
@@ -207,21 +216,29 @@ constexpr auto all_extents_equal(binary_tensor_expression<T,EL,ER,OP> const& exp
   using ::operator==;
   using ::operator!=;
 
-	if constexpr ( std::is_same<T,EL>::value )
-      if(e !=  expr.el.extents())
-	    return false;
+	if constexpr ( std::is_same<T,EL>::value ) {
+		if (e !=  expr.el.extents()) {
+			return false;
+		}
+	}
 
-	if constexpr ( std::is_same<T,ER>::value )
-      if(e != expr.er.extents())
-	    return false;
+	if constexpr ( std::is_same<T,ER>::value ) {
+		if (e != expr.er.extents()) {
+			return false;
+	  	}
+	}
 
-	if constexpr ( detail::has_tensor_types<T,EL>::value )
-      if(!all_extents_equal(expr.el, e))
-	    return false;
+	if constexpr ( detail::has_tensor_types<T,EL>::value ) {
+		if (!all_extents_equal(expr.el, e)) {
+			return false;
+	  	}
+	}
 
-	if constexpr ( detail::has_tensor_types<T,ER>::value )
-      if(!all_extents_equal(expr.er, e))
-	    return false;
+	if constexpr ( detail::has_tensor_types<T,ER>::value ) {
+		if (!all_extents_equal(expr.er, e)) {
+			return false;
+	  	}
+	}
 
 	return true;
 }
@@ -234,16 +251,19 @@ constexpr auto all_extents_equal(unary_tensor_expression<T,E,OP> const& expr, ex
 	static_assert(detail::has_tensor_types<T,unary_tensor_expression<T,E,OP>>::value,
 	              "Error in boost::numeric::ublas::detail::all_extents_equal: Expression to evaluate should contain tensors.");
 
-  using ::operator==;
+	using ::operator==;
 
-	if constexpr ( std::is_same<T,E>::value )
-      if(e != expr.e.extents())
-	    	return false;
+	if constexpr ( std::is_same<T,E>::value ) {
+ 		if (e != expr.e.extents()) {
+			return false;
+	  }
+	}
 
-	if constexpr ( detail::has_tensor_types<T,E>::value )
-      if(!all_extents_equal(expr.e, e))
-	    	return false;
-
+	if constexpr ( detail::has_tensor_types<T,E>::value ) {
+		if (!all_extents_equal(expr.e, e)) {
+			return false;
+	  	}
+	}
 	return true;
 }
 
@@ -263,13 +283,16 @@ namespace boost::numeric::ublas::detail
 template<class tensor_type, class derived_type>
 inline void eval(tensor_type& lhs, tensor_expression<tensor_type, derived_type> const& expr)
 {
-	if constexpr (detail::has_tensor_types<tensor_type, tensor_expression<tensor_type,derived_type> >::value )
-	    if(!detail::all_extents_equal(expr, lhs.extents() ))
-	    	throw std::runtime_error("Error in boost::numeric::ublas::tensor_core: expression contains tensors with different shapes.");
+	if constexpr (detail::has_tensor_types<tensor_type, tensor_expression<tensor_type,derived_type> >::value ) {
+		if (!detail::all_extents_equal(expr, lhs.extents() )) {
+			throw std::runtime_error("Error in boost::numeric::ublas::tensor_core: expression contains tensors with different shapes.");
+		}
+	}
 
 #pragma omp parallel for
-	for(auto i = 0u; i < lhs.size(); ++i)
+	for (auto i = 0u; i < lhs.size(); ++i) {
 		lhs(i) = expr()(i);
+	}
 }
 
 /** @brief Evaluates expression for a tensor_core
@@ -292,13 +315,14 @@ inline void eval(tensor_type& lhs, tensor_expression<other_tensor_type, derived_
 		"tensor_type and tensor_expresssion should have same value type"
 	);
 
-	if ( !detail::all_extents_equal(expr, lhs.extents() ) ){
+	if ( !detail::all_extents_equal(expr, lhs.extents() ) ) {
 		throw std::runtime_error("Error in boost::numeric::ublas::tensor_core: expression contains tensors with different shapes.");
 	}   	
 	
 	#pragma omp parallel for
-	for(auto i = 0u; i < lhs.size(); ++i)
+	for (auto i = 0u; i < lhs.size(); ++i) {
 		lhs(i) = expr()(i);
+	}
 }
 
 /** @brief Evaluates expression for a tensor_core
@@ -312,13 +336,16 @@ template<class tensor_type, class derived_type, class unary_fn>
 inline void eval(tensor_type& lhs, tensor_expression<tensor_type, derived_type> const& expr, unary_fn const fn)
 {
 
-	if constexpr (detail::has_tensor_types< tensor_type, tensor_expression<tensor_type,derived_type> >::value )
-	    if(!detail::all_extents_equal( expr, lhs.extents() ))
+	if constexpr (detail::has_tensor_types< tensor_type, tensor_expression<tensor_type,derived_type> >::value ) {
+	    if (!detail::all_extents_equal( expr, lhs.extents() )) {
 	    	throw std::runtime_error("Error in boost::numeric::ublas::tensor_core: expression contains tensors with different shapes.");
+		}
+	}
 
 	#pragma omp parallel for
-	for(auto i = 0u; i < lhs.size(); ++i)
+	for (auto i = 0u; i < lhs.size(); ++i) {
 		fn(lhs(i), expr()(i));
+	}
 }
 
 
@@ -334,8 +361,9 @@ template<class tensor_type, class unary_fn>
 inline void eval(tensor_type& lhs, unary_fn const& fn)
 {
 #pragma omp parallel for
-	for(auto i = 0u; i < lhs.size(); ++i)
+	for (auto i = 0u; i < lhs.size(); ++i) {
 		fn(lhs(i));
+	}
 }
 
 

--- a/include/boost/numeric/ublas/tensor/extents/extents_functions.hpp
+++ b/include/boost/numeric/ublas/tensor/extents/extents_functions.hpp
@@ -191,8 +191,9 @@ template<boost::numeric::ublas::integral T, T n, T m>
   boost::numeric::ublas::extents_core<T,n> const& lhs,
   boost::numeric::ublas::extents_core<T,m> const& rhs )
 {
-  if constexpr(m != n)
+  if constexpr(m != n) {
     return false;
+  }
   return std::equal( begin(lhs), end  (lhs), begin(rhs) );
 }
 
@@ -201,8 +202,9 @@ template<boost::numeric::ublas::integral T, T n, T m>
   boost::numeric::ublas::extents_core<T,n> const& lhs,
   boost::numeric::ublas::extents_core<T,m> const& rhs )
 {
-  if constexpr(m == n)
+  if constexpr(m == n) {
     return false;
+  }
   return !(lhs == rhs) ;
 }
 

--- a/include/boost/numeric/ublas/tensor/function/inner_prod.hpp
+++ b/include/boost/numeric/ublas/tensor/function/inner_prod.hpp
@@ -48,15 +48,18 @@ inline decltype(auto) inner_prod(tensor_core< TE1 > const &a, tensor_core< TE2 >
     "Both the tensor should have the same value_type"
     );
 
-  if (a.rank() != b.rank())
+  if (a.rank() != b.rank()) {
     throw std::length_error("error in boost::numeric::ublas::inner_prod: Rank of both the tensors must be the same.");
+  }
 
-  if (a.empty() || b.empty())
-            throw std::length_error("error in boost::numeric::ublas::inner_prod: Tensors should not be empty.");
+  if (a.empty() || b.empty()) {
+    throw std::length_error("error in boost::numeric::ublas::inner_prod: Tensors should not be empty.");
+  }
 
   //if (a.extents() != b.extents())
-  if (::operator!=(a.extents(),b.extents()))
+  if (::operator!=(a.extents(),b.extents())) {
     throw std::length_error("error in boost::numeric::ublas::inner_prod: Tensor extents should be the same.");
+  }
 
   return inner(a.rank(), a.extents().data(),
                a.data(), a.strides().data(),

--- a/include/boost/numeric/ublas/tensor/function/outer_prod.hpp
+++ b/include/boost/numeric/ublas/tensor/function/outer_prod.hpp
@@ -158,8 +158,9 @@ inline auto outer_prod(tensor_core<TEA> const &a, tensor_core<TEB> const &b)
   static_assert(std::is_same_v<resizableA_tag, storage_resizable_container_tag>);
   static_assert(std::is_same_v<resizableB_tag, storage_resizable_container_tag>);
 
-  if (a.empty() || b.empty())
+  if (a.empty() || b.empty()) {
     throw std::runtime_error("error in boost::numeric::ublas::outer_prod: tensors should not be empty.");
+  }
 
   auto const& na = a.extents();
   auto const& nb = b.extents();
@@ -260,8 +261,9 @@ inline decltype(auto) outer_prod(tensor_core<TEA> const &a, tensor_core<TEB> con
   constexpr auto extentsB_size = std::tuple_size_v<extentsB>;
 
 
-  if (a.empty() || b.empty())
+  if (a.empty() || b.empty()) {
     throw std::runtime_error("error in boost::numeric::ublas::outer_prod: tensors should not be empty.");
+  }
 
   auto nc = extentsC{};
 

--- a/include/boost/numeric/ublas/tensor/function/real.hpp
+++ b/include/boost/numeric/ublas/tensor/function/real.hpp
@@ -64,8 +64,9 @@ auto real(detail::tensor_expression< tensor_core< TE > ,D > const& expr)
   using return_tensor_engine = tensor_engine<extents_type,layout_type,storage_type>;
   using return_tensor_type = tensor_core<return_tensor_engine>;
 
-  if( ublas::empty ( detail::retrieve_extents( expr  ) ) )
+  if( ublas::empty ( detail::retrieve_extents( expr ))){
     throw std::runtime_error("error in boost::numeric::ublas::real: tensors should not be empty.");
+  }
 
   auto a = tensor_type( expr );
   auto c = return_tensor_type( a.extents() );

--- a/include/boost/numeric/ublas/tensor/function/reshape.hpp
+++ b/include/boost/numeric/ublas/tensor/function/reshape.hpp
@@ -63,8 +63,9 @@ template< class E, class D,
   auto const& efrom  = t.extents();
   auto const& eto    = e();
 
-  if( ::operator==(efrom,eto) )
+  if( ::operator==(efrom,eto) ){
     return t;
+  }
 
   auto const to_size   = product(eto);
   auto const from_size = product(efrom);

--- a/include/boost/numeric/ublas/tensor/function/tensor_times_matrix.hpp
+++ b/include/boost/numeric/ublas/tensor/function/tensor_times_matrix.hpp
@@ -78,9 +78,9 @@ inline decltype(auto) prod( tensor_core< TE > const &a, matrix<T,L,A> const &b, 
   assert( p != 0 );
   assert( p == ublas::size(na));
 
-  if( m == 0 )       throw std::length_error("Error in boost::numeric::ublas::ttm: contraction mode must be greater than zero.");
-  if( p <  m )       throw std::length_error("Error in boost::numeric::ublas::ttm: tensor order must be greater than or equal to the specified mode.");
-  if(na[m-1]!=nb[1]) throw std::invalid_argument("Error in boost::numeric::ublas::ttm: 2nd extent of B and m-th extent of A must be equal.");
+  if( m == 0 )      { throw std::length_error("Error in boost::numeric::ublas::ttm: contraction mode must be greater than zero."); }
+  if( p <  m )      { throw std::length_error("Error in boost::numeric::ublas::ttm: tensor order must be greater than or equal to the specified mode."); }
+  if(na[m-1]!=nb[1]){  throw std::invalid_argument("Error in boost::numeric::ublas::ttm: 2nd extent of B and m-th extent of A must be equal."); }
 
 
   auto nc_base = na.base();
@@ -151,7 +151,7 @@ inline decltype(auto) prod(tensor_core<TE> const &a, matrix<T,L,A> const &b)
   static_assert( m != 0);
   static_assert( p <  m);
 
-  if(na[m-1]!=nb[1]) throw std::invalid_argument("Error in boost::numeric::ublas::ttm: 2nd extent of B and m-th extent of A must be equal.");
+  if(na[m-1]!=nb[1]){ throw std::invalid_argument("Error in boost::numeric::ublas::ttm: 2nd extent of B and m-th extent of A must be equal."); }
 
   auto nc_base = na.base();
   auto wb = ublas::to_strides(nb,layout_type{});

--- a/include/boost/numeric/ublas/tensor/function/tensor_times_tensor.hpp
+++ b/include/boost/numeric/ublas/tensor/function/tensor_times_tensor.hpp
@@ -112,9 +112,11 @@ inline decltype(auto) prod(tensor_core< TEA > const &a,
   auto const &na = a.extents();
   auto const &nb = b.extents();
 
-  for (auto i = 0ul; i < q; ++i)
-    if (na.at(phia.at(i) - 1) != nb.at(phib.at(i) - 1))
+  for (auto i = 0ul; i < q; ++i) {
+    if (na.at(phia.at(i) - 1) != nb.at(phib.at(i) - 1)) {
       throw std::runtime_error("error in ublas::prod: permutations of the extents are not correct.");
+    }
+  }
 
   auto const r = pa - q;
   auto const s = pb - q;
@@ -130,20 +132,24 @@ inline decltype(auto) prod(tensor_core< TEA > const &a,
   auto nc_base = extents_base (std::max(size,std::size_t{2}),std::size_t{1});
 
   //for (auto i = 0ul; i < phia.size(); ++i)
-  for (auto p : phia)
+  for (auto p : phia) {
     *std::remove(phia1.begin(), phia1.end(), p) = p;
+  }
   //phia1.erase( std::remove(phia1.begin(), phia1.end(), phia.at(i)),  phia1.end() )  ;
 
-  for (auto i = 0ul; i < r; ++i)
+  for (auto i = 0ul; i < r; ++i) {
     nc_base[i] = na[phia1[i] - 1];
+  }
 
   //for (auto i = 0ul; i < phib.size(); ++i)
-  for (auto p : phib)
+  for (auto p : phib) {
     *std::remove(phib1.begin(), phib1.end(), p) = p;
+  }
   //phib1.erase( std::remove(phib1.begin(), phib1.end(), phia.at(i)), phib1.end() )  ;
 
-  for (auto i = 0ul; i < s; ++i)
+  for (auto i = 0ul; i < s; ++i) {
     nc_base[r + i] = nb[phib1[i] - 1];
+  }
 
   assert(phia1.size() == pa);
   assert(phib1.size() == pb);
@@ -260,9 +266,11 @@ inline auto prod(tensor_core<TEA> const &a,
   auto const &na = a.extents();
   auto const &nb = b.extents();
 
-  for (auto i = 0ul; i < q; ++i)
-    if (na.at(phia.at(i) - 1) != nb.at(phib.at(i) - 1))
+  for (auto i = 0ul; i < q; ++i) {
+    if (na.at(phia.at(i) - 1) != nb.at(phib.at(i) - 1)) {
       throw std::runtime_error("error in ublas::prod: permutations of the extents are not correct.");
+    }
+  }
 
   constexpr auto r = pa - q;
   constexpr auto s = pb - q;
@@ -276,19 +284,23 @@ inline auto prod(tensor_core<TEA> const &a,
   using return_extents_type = extents<msz>;
   auto nc_base = std::array<std::size_t,msz>{};
 
-  for (auto i = 0ul; i < phia.size(); ++i)
+  for (auto i = 0ul; i < phia.size(); ++i) {
     *std::remove(phia1.begin(), phia1.end(), phia.at(i)) = phia.at(i);
+  }
   //phia1.erase( std::remove(phia1.begin(), phia1.end(), phia.at(i)),  phia1.end() )  ;
 
-  for (auto i = 0ul; i < phib.size(); ++i)
+  for (auto i = 0ul; i < phib.size(); ++i) {
     *std::remove(phib1.begin(), phib1.end(), phib.at(i)) = phib.at(i);
+  }
   //phib1.erase( std::remove(phib1.begin(), phib1.end(), phia.at(i)), phib1.end() )  ;
 
-  for (auto i = 0ul; i < r; ++i)
+  for (auto i = 0ul; i < r; ++i) {
     nc_base[i] = na[phia1[i] - 1];
+  }
 
-  for (auto i = 0ul; i < s; ++i)
+  for (auto i = 0ul; i < s; ++i) {
     nc_base[r+i] = nb[phib1[i] - 1];
+  }
 
   auto nc = return_extents_type(nc_base);
 
@@ -328,8 +340,6 @@ inline decltype(auto) prod(tensor_core<TEA> const &a,
 {
   return prod(a, b, phi, phi);
 }
-
-
 
 
 } // namespace boost::numeric::ublas

--- a/include/boost/numeric/ublas/tensor/function/tensor_times_tensor.hpp
+++ b/include/boost/numeric/ublas/tensor/function/tensor_times_tensor.hpp
@@ -101,13 +101,13 @@ inline decltype(auto) prod(tensor_core< TEA > const &a,
 
   auto const q = std::size_t{phia.size()};
 
-  if (pa == 0ul)        throw std::runtime_error("error in ublas::prod(ttt): order of left-hand side tensor must be greater than 0.");
-  if (pb == 0ul)        throw std::runtime_error("error in ublas::prod(ttt): order of right-hand side tensor must be greater than 0.");
-  if (pa < q)           throw std::runtime_error("error in ublas::prod(ttt): number of contraction dimensions cannot be greater than the order of the left-hand side tensor.");
-  if (pb < q)           throw std::runtime_error("error in ublas::prod(ttt): number of contraction dimensions cannot be greater than the order of the right-hand side tensor.");
-  if (q != phib.size()) throw std::runtime_error("error in ublas::prod(ttt): permutation tuples must have the same length.");
-  if (pa < phia.size()) throw std::runtime_error("error in ublas::prod(ttt): permutation tuple for the left-hand side tensor cannot be greater than the corresponding order.");
-  if (pb < phib.size()) throw std::runtime_error("error in ublas::prod(ttt): permutation tuple for the right-hand side tensor cannot be greater than the corresponding order.");
+  if (pa == 0ul)       { throw std::runtime_error("error in ublas::prod(ttt): order of left-hand side tensor must be greater than 0."); }
+  if (pb == 0ul)       { throw std::runtime_error("error in ublas::prod(ttt): order of right-hand side tensor must be greater than 0."); }
+  if (pa < q)          { throw std::runtime_error("error in ublas::prod(ttt): number of contraction dimensions cannot be greater than the order of the left-hand side tensor."); }
+  if (pb < q)          { throw std::runtime_error("error in ublas::prod(ttt): number of contraction dimensions cannot be greater than the order of the right-hand side tensor."); }
+  if (q != phib.size()){ throw std::runtime_error("error in ublas::prod(ttt): permutation tuples must have the same length."); }
+  if (pa < phia.size()){ throw std::runtime_error("error in ublas::prod(ttt): permutation tuple for the left-hand side tensor cannot be greater than the corresponding order."); }
+  if (pb < phib.size()){ throw std::runtime_error("error in ublas::prod(ttt): permutation tuple for the right-hand side tensor cannot be greater than the corresponding order."); }
 
   auto const &na = a.extents();
   auto const &nb = b.extents();

--- a/include/boost/numeric/ublas/tensor/function/tensor_times_vector.hpp
+++ b/include/boost/numeric/ublas/tensor/function/tensor_times_vector.hpp
@@ -77,10 +77,10 @@ inline decltype(auto) prod( tensor_core< TE > const &a, vector<T, A> const &b, c
   static_assert(std::is_same_v<resize_tag,storage_resizable_container_tag>);
   static_assert(is_dynamic_v<shape>);
 
-  if (m == 0ul)  throw std::length_error("error in boost::numeric::ublas::prod(ttv): contraction mode must be greater than zero.");
-  if (p < m)     throw std::length_error("error in boost::numeric::ublas::prod(ttv): rank of tensor must be greater than or equal to the contraction mode.");
-  if (a.empty()) throw std::length_error("error in boost::numeric::ublas::prod(ttv): first argument tensor should not be empty.");
-  if (b.empty()) throw std::length_error("error in boost::numeric::ublas::prod(ttv): second argument vector should not be empty.");
+  if (m == 0ul)  { throw std::length_error("error in boost::numeric::ublas::prod(ttv): contraction mode must be greater than zero."); }
+  if (p < m)     { throw std::length_error("error in boost::numeric::ublas::prod(ttv): rank of tensor must be greater than or equal to the contraction mode."); }
+  if (a.empty()) { throw std::length_error("error in boost::numeric::ublas::prod(ttv): first argument tensor should not be empty."); }
+  if (b.empty()) { throw std::length_error("error in boost::numeric::ublas::prod(ttv): second argument vector should not be empty."); }
 
   auto const& na = a.extents();
   auto nb = extents<2>{std::size_t(b.size()),std::size_t(1ul)};
@@ -89,9 +89,11 @@ inline decltype(auto) prod( tensor_core< TE > const &a, vector<T, A> const &b, c
   auto const sz = std::max( std::size_t(ublas::size(na)-1u), std::size_t(2) );
   auto nc_base = typename shape::base_type(sz,1);
 
-  for (auto i = 0ul, j = 0ul; i < p; ++i)
-    if (i != m - 1)
+  for (auto i = 0ul, j = 0ul; i < p; ++i) {
+    if (i != m - 1) {
       nc_base[j++] = na.at(i);
+    }
+  }
 
   auto nc = shape(nc_base);
 
@@ -150,18 +152,20 @@ inline auto prod( tensor_core< TE > const &a, vector<T, A> const &b, const std::
 
   static_assert(std::is_same_v<resizeable_tag,storage_resizable_container_tag >);
 
-  if (m == 0ul)  throw std::length_error("error in boost::numeric::ublas::prod(ttv): contraction mode must be greater than zero.");
-  if (p < m)     throw std::length_error("error in boost::numeric::ublas::prod(ttv): rank of tensor must be greater than or equal to the modus.");
-  if (a.empty()) throw std::length_error("error in boost::numeric::ublas::prod(ttv): first argument tensor should not be empty.");
-  if (b.empty()) throw std::length_error("error in boost::numeric::ublas::prod(ttv): second argument vector should not be empty.");
+  if (m == 0ul)  { throw std::length_error("error in boost::numeric::ublas::prod(ttv): contraction mode must be greater than zero."); }
+  if (p < m)     { throw std::length_error("error in boost::numeric::ublas::prod(ttv): rank of tensor must be greater than or equal to the modus."); }
+  if (a.empty()) { throw std::length_error("error in boost::numeric::ublas::prod(ttv): first argument tensor should not be empty."); }
+  if (b.empty()) { throw std::length_error("error in boost::numeric::ublas::prod(ttv): second argument vector should not be empty."); }
 
   auto const& na = a.extents();
 
   auto nc_base = typename shape_c::base_type{};
   std::fill(nc_base.begin(), nc_base.end(),std::size_t(1));
-  for (auto i = 0ul, j = 0ul; i < p; ++i)
-    if (i != m - 1)
+  for (auto i = 0ul, j = 0ul; i < p; ++i) {
+    if (i != m - 1) {
       nc_base[j++] = na.at(i);
+    }
+  }
 
   auto nc = shape_c(std::move(nc_base));
   auto nb = shape_b{b.size(),1UL};
@@ -212,8 +216,8 @@ inline auto prod( tensor_core< TE > const &a, vector<T, A> const &b)
 
   constexpr auto p = std::tuple_size_v<shape>;
 
-  if (a.empty()) throw std::length_error("error in boost::numeric::ublas::prod(ttv): first argument tensor should not be empty.");
-  if (b.empty()) throw std::length_error("error in boost::numeric::ublas::prod(ttv): second argument vector should not be empty.");
+  if (a.empty()) { throw std::length_error("error in boost::numeric::ublas::prod(ttv): first argument tensor should not be empty."); }
+  if (b.empty()) { throw std::length_error("error in boost::numeric::ublas::prod(ttv): second argument vector should not be empty."); }
 
   auto const& na = a.extents();
 

--- a/include/boost/numeric/ublas/tensor/multi_index_utility.hpp
+++ b/include/boost/numeric/ublas/tensor/multi_index_utility.hpp
@@ -247,8 +247,9 @@ struct index_position_pairs_impl
         using has_index_type = has_index<index_type, tuple_right>;
         using get_index_type = index_position<index_type,tuple_right>;
         using next_type      = index_position_pairs_impl<r+1,m>;
-        if constexpr ( has_index_type::value && index_type::value != 0)
+        if constexpr ( has_index_type::value && index_type::value != 0) {
             out[p++] = std::make_pair(r-1,get_index_type::value);
+        }
         next_type::run( out, lhs, rhs, p );
     }
 };
@@ -266,8 +267,9 @@ struct index_position_pairs_impl<m,m>
         using index_type     = std::tuple_element_t<m-1,tuple_left>;
         using has_index_type = has_index<index_type, tuple_right>;
         using get_index_type = index_position<index_type, tuple_right>;
-        if constexpr ( has_index_type::value && index_type::value != 0 )
+        if constexpr ( has_index_type::value && index_type::value != 0 ) {
             out[p] = std::make_pair(m-1,get_index_type::value);
+        }
     }
 };
 

--- a/include/boost/numeric/ublas/tensor/multiplication.hpp
+++ b/include/boost/numeric/ublas/tensor/multiplication.hpp
@@ -15,8 +15,7 @@
 
 #include <cassert>
 
-namespace boost::numeric::ublas {
-namespace detail::recursive {
+namespace boost::numeric::ublas::detail::recursive {
 
 
 /** @brief Computes the tensor-times-tensor product for q contraction modes
@@ -578,8 +577,7 @@ void outer(SizeType const k,
 }
 
 
-} // namespace detail::recursive
-} // namespace boost::numeric::ublas
+} // namespace boost::numeric::ublas::detail::recursive
 
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/include/boost/numeric/ublas/tensor/operators_comparison.hpp
+++ b/include/boost/numeric/ublas/tensor/operators_comparison.hpp
@@ -40,22 +40,27 @@ constexpr bool compare(tensor_core<T1> const& lhs, tensor_core<T2> const& rhs, B
     );
 
     if(::operator!=(lhs.extents(),rhs.extents())){
-        if constexpr(!std::is_same<BinaryPred,std::equal_to<>>::value && !std::is_same<BinaryPred,std::not_equal_to<>>::value)
+        if constexpr(!std::is_same<BinaryPred,std::equal_to<>>::value && !std::is_same<BinaryPred,std::not_equal_to<>>::value) {
             throw std::runtime_error(
                 "boost::numeric::ublas::detail::compare(tensor_core<T1> const&, tensor_core<T2> const&, BinaryPred) : "
                 "cannot compare tensors with different shapes."
             );
-        else
+        } else {
             return false;
+        }
     }
 
-    if constexpr(std::is_same<BinaryPred,std::greater<>>::value || std::is_same<BinaryPred,std::less<>>::value)
-        if(lhs.empty())
+    if constexpr(std::is_same<BinaryPred,std::greater<>>::value || std::is_same<BinaryPred,std::less<>>::value){
+        if(lhs.empty()){
             return false;
+        }
+    }
 
-    for(auto i = 0u; i < lhs.size(); ++i)
-        if(!pred(lhs(i), rhs(i)))
+    for(auto i = 0u; i < lhs.size(); ++i){
+        if(!pred(lhs(i), rhs(i))){
             return false;
+        }
+    }
     return true;
 }
 
@@ -63,9 +68,11 @@ template<class T, class UnaryPred>
 [[nodiscard]] inline 
 constexpr bool compare(tensor_core<T> const& rhs, UnaryPred pred)
 {
-    for(auto i = 0u; i < rhs.size(); ++i)
-        if(!pred(rhs(i)))
+    for(auto i = 0u; i < rhs.size(); ++i){
+        if(!pred(rhs(i))){
             return false;
+        }
+    }
     return true;
 }
 
@@ -77,25 +84,26 @@ constexpr bool compare(tensor_expression<T1,L> const& lhs, tensor_expression<T2,
     constexpr bool lhs_is_tensor = std::is_same<T1,L>::value;
     constexpr bool rhs_is_tensor = std::is_same<T2,R>::value;
     
-    if constexpr (lhs_is_tensor && rhs_is_tensor)
+    if constexpr (lhs_is_tensor && rhs_is_tensor) {
         return compare(static_cast<T1 const&>( lhs ), static_cast<T2 const&>( rhs ), pred);
-    else if constexpr (lhs_is_tensor && !rhs_is_tensor)
+    } else if constexpr (lhs_is_tensor && !rhs_is_tensor) {
         return compare(static_cast<T1 const&>( lhs ), T2( rhs ), pred);
-    else if constexpr (!lhs_is_tensor && rhs_is_tensor)
+    } else if constexpr (!lhs_is_tensor && rhs_is_tensor) {
         return compare(T1( lhs ), static_cast<T2 const&>( rhs ), pred);
-    else
+    } else {
         return compare(T1( lhs ), T2( rhs ), pred);
-
+    }
 }
 
 template<class T, class D, class UnaryPred>
 [[nodiscard]]
 constexpr bool compare(tensor_expression<T,D> const& expr, UnaryPred pred)
 {
-    if constexpr (std::is_same<T,D>::value)
+    if constexpr (std::is_same<T,D>::value) {
         return compare(static_cast<T const&>( expr ), pred);
-    else
+    } else {
         return compare(T( expr ), pred);
+    }
 }
 
 } // namespace boost::numeric::ublas::detail


### PR DESCRIPTION
As mentioned in issue #112. This PR adds two earlier excluded `clang-tidy` checks: 
- `google-readability-braces-around-statements`
- `readability-braces-around-statements`
The tests were not refractored because of incoming major changes proposed in #122. Both the tensor implementation and the examples were refractored. Morever since there is no definite style guide, I did not refractor too aggressively and tried to match the general style of each file so as to not make some lines stand out.