### PR TITLE
Fix deprecated copy warnings

### DIFF
--- a/include/boost/numeric/ublas/banded.hpp
+++ b/include/boost/numeric/ublas/banded.hpp
@@ -493,6 +493,11 @@ public:
             const_iterator1 (const iterator1 &it):
                 container_const_reference<self_type> (it ()), it1_ (it.it1_), it2_ (it.it2_) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator1 (const const_iterator1&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             const_iterator1 &operator ++ () {
@@ -668,6 +673,11 @@ public:
             iterator1 (self_type &m, size_type it1, size_type it2):
                 container_reference<self_type> (m), it1_ (it1), it2_ (it2) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            iterator1 (const iterator1&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             iterator1 &operator ++ () {
@@ -812,6 +822,11 @@ public:
             BOOST_UBLAS_INLINE
             const_iterator2 (const iterator2 &it):
                 container_const_reference<self_type> (it ()), it1_ (it.it1_), it2_ (it.it2_) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator2 (const const_iterator2&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE
@@ -988,6 +1003,11 @@ public:
             BOOST_UBLAS_INLINE
             iterator2 (self_type &m, size_type it1, size_type it2):
                 container_reference<self_type> (m), it1_ (it1), it2_ (it2) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            iterator2 (const iterator2&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE
@@ -1578,6 +1598,11 @@ public:
             const_iterator1 (const iterator1 &it):
                 container_const_reference<self_type> (it ()), it1_ (it.it1_) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator1 (const const_iterator1&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             const_iterator1 &operator ++ () {
@@ -1766,6 +1791,11 @@ public:
             iterator1 (self_type &m, const subiterator1_type &it1):
                 container_reference<self_type> (m), it1_ (it1) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            iterator1 (const iterator1&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             iterator1 &operator ++ () {
@@ -1923,6 +1953,11 @@ public:
             BOOST_UBLAS_INLINE
             const_iterator2 (const iterator2 &it):
                 container_const_reference<self_type> (it ()), it2_ (it.it2_) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator2 (const const_iterator2&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE
@@ -2111,6 +2146,11 @@ public:
             BOOST_UBLAS_INLINE
             iterator2 (self_type &m, const subiterator2_type &it2):
                 container_reference<self_type> (m), it2_ (it2) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            iterator2 (const iterator2&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE

--- a/include/boost/numeric/ublas/detail/iterator.hpp
+++ b/include/boost/numeric/ublas/detail/iterator.hpp
@@ -675,6 +675,11 @@ namespace boost { namespace numeric { namespace ublas {
         indexed_iterator (container_type &c, size_type it):
             container_reference<container_type> (c), it_ (it) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+        BOOST_UBLAS_INLINE
+        indexed_iterator (const indexed_iterator&) = default;
+#endif
+
         // Arithmetic
         BOOST_UBLAS_INLINE
         indexed_iterator &operator ++ () {

--- a/include/boost/numeric/ublas/matrix.hpp
+++ b/include/boost/numeric/ublas/matrix.hpp
@@ -505,6 +505,11 @@ namespace boost { namespace numeric {
             const_iterator1 (const iterator1 &it):
                 container_const_reference<self_type> (it ()), it_ (it.it_) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator1 (const const_iterator1&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             const_iterator1 &operator ++ () {
@@ -683,6 +688,11 @@ namespace boost { namespace numeric {
             iterator1 (self_type &m, const subiterator_type &it):
                 container_reference<self_type> (m), it_ (it) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            iterator1 (const iterator1&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             iterator1 &operator ++ () {
@@ -827,6 +837,11 @@ namespace boost { namespace numeric {
             BOOST_UBLAS_INLINE
             const_iterator2 (const iterator2 &it):
                 container_const_reference<self_type> (it ()), it_ (it.it_) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator2 (const const_iterator2&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE
@@ -1005,6 +1020,11 @@ namespace boost { namespace numeric {
             BOOST_UBLAS_INLINE
             iterator2 (self_type &m, const subiterator_type &it):
                 container_reference<self_type> (m), it_ (it) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            iterator2 (const iterator2&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE
@@ -1588,6 +1608,11 @@ namespace boost { namespace numeric {
             const_iterator1 (const iterator1 &it):
                 container_const_reference<self_type> (it ()), it_ (it.it_) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator1 (const const_iterator1&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             const_iterator1 &operator ++ () {
@@ -1766,6 +1791,11 @@ namespace boost { namespace numeric {
             iterator1 (self_type &m, const subiterator_type &it):
                 container_reference<self_type> (m), it_ (it) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            iterator1 (const iterator1&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             iterator1 &operator ++ () {
@@ -1910,6 +1940,11 @@ namespace boost { namespace numeric {
             BOOST_UBLAS_INLINE
             const_iterator2 (const iterator2 &it):
                 container_const_reference<self_type> (it ()), it_ (it.it_) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator2 (const const_iterator2&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE
@@ -2088,6 +2123,11 @@ namespace boost { namespace numeric {
             BOOST_UBLAS_INLINE
             iterator2 (self_type &m, const subiterator_type &it):
                 container_reference<self_type> (m), it_ (it) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            iterator2 (const iterator2&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE
@@ -2671,6 +2711,11 @@ namespace boost { namespace numeric {
             const_iterator1 (const iterator1 &it):
                 container_const_reference<self_type> (it ()), i_ (it.i_), j_ (it.j_), it_ (it.it_) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator1 (const const_iterator1&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             const_iterator1 &operator ++ () {
@@ -2866,6 +2911,11 @@ namespace boost { namespace numeric {
             iterator1 (self_type &m, size_type i, size_type j, const subiterator_type &it):
                 container_reference<self_type> (m), i_ (i), j_ (j), it_ (it) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            iterator1 (const iterator1&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             iterator1 &operator ++ () {
@@ -3027,6 +3077,11 @@ namespace boost { namespace numeric {
             BOOST_UBLAS_INLINE
             const_iterator2 (const iterator2 &it):
                 container_const_reference<self_type> (it ()), i_ (it.i_), j_ (it.j_), it_ (it.it_) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator2 (const const_iterator2&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE
@@ -3222,6 +3277,11 @@ namespace boost { namespace numeric {
             BOOST_UBLAS_INLINE
             iterator2 (self_type &m, size_type i, size_type j, const subiterator_type &it):
                 container_reference<self_type> (m), i_ (i), j_ (j), it_ (it) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            iterator2 (const iterator2&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE
@@ -3580,6 +3640,11 @@ namespace boost { namespace numeric {
             const_iterator1 (const self_type &m):
                 container_const_reference<self_type> (m) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator1 (const const_iterator1&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             const_iterator1 &operator ++ () {
@@ -3725,6 +3790,11 @@ namespace boost { namespace numeric {
             BOOST_UBLAS_INLINE
             const_iterator2 (const self_type &m):
                 container_const_reference<self_type> (m) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator2 (const const_iterator2&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE
@@ -4223,6 +4293,11 @@ namespace boost { namespace numeric {
             const_iterator2 (const self_type &m, const const_subiterator_type &it):
                 container_const_reference<self_type> (m), it_ (it) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator2 (const const_iterator2&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             const_iterator2 &operator ++ () {
@@ -4565,6 +4640,11 @@ namespace boost { namespace numeric {
             const_iterator1 (const scalar_matrix &m, const const_subiterator_type &it1, const const_subiterator_type &it2):
                 container_const_reference<scalar_matrix> (m), it1_ (it1), it2_ (it2) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator1 (const const_iterator1&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             const_iterator1 &operator ++ () {
@@ -4745,6 +4825,11 @@ namespace boost { namespace numeric {
             BOOST_UBLAS_INLINE
             const_iterator2 (const scalar_matrix &m, const const_subiterator_type &it1, const const_subiterator_type &it2):
                 container_const_reference<scalar_matrix> (m), it1_ (it1), it2_ (it2) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator2 (const const_iterator2&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE
@@ -5304,6 +5389,11 @@ namespace boost { namespace numeric {
             const_iterator1 (const iterator1 &it):
                 container_const_reference<self_type> (it ()), it_ (it.it_) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator1 (const const_iterator1&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             const_iterator1 &operator ++ () {
@@ -5483,6 +5573,11 @@ namespace boost { namespace numeric {
             iterator1 (self_type &m, const subiterator_type &it):
                 container_reference<self_type> (m), it_ (it) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            iterator1 (const iterator1&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             iterator1 &operator ++ () {
@@ -5627,6 +5722,11 @@ namespace boost { namespace numeric {
             BOOST_UBLAS_INLINE
             const_iterator2 (const iterator2 &it):
                 container_const_reference<self_type> (it ()), it_ (it.it_) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator2 (const const_iterator2&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE
@@ -5805,6 +5905,11 @@ namespace boost { namespace numeric {
             BOOST_UBLAS_INLINE
             iterator2 (self_type &m, const subiterator_type &it):
                 container_reference<self_type> (m), it_ (it) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            iterator2 (const iterator2&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE

--- a/include/boost/numeric/ublas/matrix_expression.hpp
+++ b/include/boost/numeric/ublas/matrix_expression.hpp
@@ -49,6 +49,11 @@ public:
 	explicit matrix_reference (referred_type &e):
 	  e_ (e) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+    BOOST_UBLAS_INLINE
+    matrix_reference (const matrix_reference&) = default;
+#endif
+
 	// Accessors
 	BOOST_UBLAS_INLINE
 	size_type size1 () const {
@@ -1613,6 +1618,11 @@ public:
 		const_iterator1 (const self_type &mu, const const_subiterator1_type &it):
 		  container_const_reference<self_type> (mu), it_ (it) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+        BOOST_UBLAS_INLINE
+        const_iterator1 (const const_iterator1&) = default;
+#endif
+
 		// Arithmetic
 		BOOST_UBLAS_INLINE
 		const_iterator1 &operator ++ () {
@@ -1783,6 +1793,11 @@ public:
 		BOOST_UBLAS_INLINE
 		const_iterator2 (const self_type &mu, const const_subiterator2_type &it):
 		  container_const_reference<self_type> (mu), it_ (it) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+        BOOST_UBLAS_INLINE
+        const_iterator2 (const const_iterator2&) = default;
+#endif
 
 		// Arithmetic
 		BOOST_UBLAS_INLINE
@@ -2170,6 +2185,11 @@ public:
 		                 const const_iterator21_type &it2, const const_iterator21_type &it2_end):
 		  container_const_reference<self_type> (mb), i_ (i), j_ (j), it1_ (it1), it1_end_ (it1_end), it2_ (it2), it2_end_ (it2_end) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+        BOOST_UBLAS_INLINE
+        const_iterator1 (const const_iterator1&) = default;
+#endif
+
 	private:
 		// Dense specializations
 		BOOST_UBLAS_INLINE
@@ -2520,6 +2540,11 @@ public:
 		                 const const_iterator12_type &it1, const const_iterator12_type &it1_end,
 		                 const const_iterator22_type &it2, const const_iterator22_type &it2_end):
 		  container_const_reference<self_type> (mb), i_ (i), j_ (j), it1_ (it1), it1_end_ (it1_end), it2_ (it2), it2_end_ (it2_end) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+        BOOST_UBLAS_INLINE
+        const_iterator2 (const const_iterator2&) = default;
+#endif
 
 	private:
 		// Dense access specializations
@@ -3071,6 +3096,11 @@ public:
 		const_iterator1 (const self_type &mbs, const const_subiterator1_type &it1, const const_iterator21_type &it2):
 		  container_const_reference<self_type> (mbs), it1_ (it1), it2_ (it2) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+        BOOST_UBLAS_INLINE
+        const_iterator1 (const const_iterator1&) = default;
+#endif
+
 		// Arithmetic
 		BOOST_UBLAS_INLINE
 		const_iterator1 &operator ++ () {
@@ -3249,6 +3279,11 @@ public:
 		BOOST_UBLAS_INLINE
 		const_iterator2 (const self_type &mbs, const const_subiterator1_type &it1, const const_iterator22_type &it2):
 		  container_const_reference<self_type> (mbs), it1_ (it1), it2_ (it2) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+        BOOST_UBLAS_INLINE
+        const_iterator2 (const const_iterator2&) = default;
+#endif
 
 		// Arithmetic
 		BOOST_UBLAS_INLINE
@@ -3599,6 +3634,11 @@ public:
 		const_iterator1 (const self_type &mbs, const const_iterator11_type &it1, const const_subiterator2_type &it2):
 		  container_const_reference<self_type> (mbs), it1_ (it1), it2_ (it2) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+        BOOST_UBLAS_INLINE
+        const_iterator1 (const const_iterator1&) = default;
+#endif
+
 		// Arithmetic
 		BOOST_UBLAS_INLINE
 		const_iterator1 &operator ++ () {
@@ -3777,6 +3817,11 @@ public:
 		BOOST_UBLAS_INLINE
 		const_iterator2 (const self_type &mbs, const const_iterator12_type &it1, const const_subiterator2_type &it2):
 		  container_const_reference<self_type> (mbs), it1_ (it1), it2_ (it2) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+        BOOST_UBLAS_INLINE
+        const_iterator2 (const const_iterator2&) = default;
+#endif
 
 		// Arithmetic
 		BOOST_UBLAS_INLINE
@@ -4130,6 +4175,11 @@ public:
 		BOOST_UBLAS_INLINE
 		const_iterator (const self_type &mvb, const const_subiterator1_type &it1):
 		  container_const_reference<self_type> (mvb), it1_ (it1) {}
+#endif
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+        BOOST_UBLAS_INLINE
+        const_iterator (const const_iterator&) = default;
 #endif
 
 	private:
@@ -4536,6 +4586,11 @@ public:
 		BOOST_UBLAS_INLINE
 		const_iterator (const self_type &mvb, const const_subiterator2_type &it2):
 		  container_const_reference<self_type> (mvb), it2_ (it2) {}
+#endif
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+        BOOST_UBLAS_INLINE
+        const_iterator (const const_iterator&) = default;
 #endif
 
 	private:
@@ -4989,6 +5044,11 @@ public:
 		  container_const_reference<self_type> (mmb), it1_ (it1), it2_ (it2) {}
 #endif
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+        BOOST_UBLAS_INLINE
+        const_iterator1 (const const_iterator1&) = default;
+#endif
+
 	private:
 		// Random access specialization
 		BOOST_UBLAS_INLINE
@@ -5249,6 +5309,11 @@ public:
 		BOOST_UBLAS_INLINE
 		const_iterator2 (const self_type &mmb, const const_iterator11_type &it1, const const_iterator22_type &it2):
 		  container_const_reference<self_type> (mmb), it1_ (it1), it2_ (it2) {}
+#endif
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+        BOOST_UBLAS_INLINE
+        const_iterator2 (const const_iterator2&) = default;
 #endif
 
 	private:

--- a/include/boost/numeric/ublas/matrix_proxy.hpp
+++ b/include/boost/numeric/ublas/matrix_proxy.hpp
@@ -57,6 +57,11 @@ namespace boost { namespace numeric { namespace ublas {
             // BOOST_UBLAS_CHECK (i_ < data_.size1 (), bad_index ());
         }
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+        BOOST_UBLAS_INLINE
+        matrix_row (const matrix_row&) = default;
+#endif
+
         // Accessors
         BOOST_UBLAS_INLINE
         size_type size () const {
@@ -257,6 +262,11 @@ namespace boost { namespace numeric { namespace ublas {
             const_iterator (const typename self_type::iterator &it):  // ISSUE self_type:: stops VC8 using std::iterator here
                 container_const_reference<self_type> (it ()), it_ (it.it_) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator (const const_iterator&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             const_iterator &operator ++ () {
@@ -361,6 +371,11 @@ namespace boost { namespace numeric { namespace ublas {
             BOOST_UBLAS_INLINE
             iterator (self_type &mr, const subiterator_type &it):
                 container_reference<self_type> (mr), it_ (it) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            iterator (const iterator&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE
@@ -529,6 +544,11 @@ namespace boost { namespace numeric { namespace ublas {
             // Early checking of preconditions here.
             // BOOST_UBLAS_CHECK (j_ < data_.size2 (), bad_index ());
         }
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+        BOOST_UBLAS_INLINE
+        matrix_column (const matrix_column&) = default;
+#endif
 
         // Accessors
         BOOST_UBLAS_INLINE
@@ -729,6 +749,11 @@ namespace boost { namespace numeric { namespace ublas {
             BOOST_UBLAS_INLINE
             const_iterator (const typename self_type::iterator &it):  // ISSUE self_type:: stops VC8 using std::iterator here
                 container_const_reference<self_type> (it ()), it_ (it.it_) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator (const const_iterator&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE
@@ -1007,6 +1032,11 @@ namespace boost { namespace numeric { namespace ublas {
             // BOOST_UBLAS_CHECK (r1_.size () == r2_.size (), bad_size ());
         }
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+        BOOST_UBLAS_INLINE
+        matrix_vector_range (const matrix_vector_range&) = default;
+#endif
+
         // Accessors
         BOOST_UBLAS_INLINE
         size_type start1 () const {
@@ -1198,6 +1228,11 @@ namespace boost { namespace numeric { namespace ublas {
             const_iterator (const typename self_type::iterator &it):  // ISSUE self_type:: stops VC8 using std::iterator here
                 container_const_reference<self_type> (it ()), it1_ (it.it1_), it2_ (it.it2_) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator (const const_iterator&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             const_iterator &operator ++ () {
@@ -1310,6 +1345,11 @@ namespace boost { namespace numeric { namespace ublas {
             BOOST_UBLAS_INLINE
             iterator (self_type &mvr, const subiterator1_type &it1, const subiterator2_type &it2):
                 container_reference<self_type> (mvr), it1_ (it1), it2_ (it2) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            iterator (const iterator&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE
@@ -1477,6 +1517,11 @@ namespace boost { namespace numeric { namespace ublas {
             // BOOST_UBLAS_CHECK (s2_.start () <= data_.size2 () &&
             //                    s2_.start () + s2_.stride () * (s2_.size () - (s2_.size () > 0)) <= data_.size2 (), bad_index ());
         }
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+        BOOST_UBLAS_INLINE
+        matrix_vector_slice (const matrix_vector_slice&) = default;
+#endif
 
         // Accessors
         BOOST_UBLAS_INLINE
@@ -1679,6 +1724,11 @@ namespace boost { namespace numeric { namespace ublas {
             const_iterator (const typename self_type::iterator &it):  // ISSUE vector:: stops VC8 using std::iterator here
                 container_const_reference<self_type> (it ()), it1_ (it.it1_), it2_ (it.it2_) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator (const const_iterator&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             const_iterator &operator ++ () {
@@ -1791,6 +1841,11 @@ namespace boost { namespace numeric { namespace ublas {
             BOOST_UBLAS_INLINE
             iterator (self_type &mvs, const subiterator1_type &it1, const subiterator2_type &it2):
                 container_reference<self_type> (mvs), it1_ (it1), it2_ (it2) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            iterator (const iterator&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE
@@ -2160,6 +2215,11 @@ namespace boost { namespace numeric { namespace ublas {
             const_iterator (const typename self_type::iterator &it):  // ISSUE self_type:: stops VC8 using std::iterator here
                 container_const_reference<self_type> (it ()), it1_ (it.it1_), it2_ (it.it2_) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator (const const_iterator&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             const_iterator &operator ++ () {
@@ -2272,6 +2332,11 @@ namespace boost { namespace numeric { namespace ublas {
             BOOST_UBLAS_INLINE
             iterator (self_type &mvi, const subiterator1_type &it1, const subiterator2_type &it2):
                 container_reference<self_type> (mvi), it1_ (it1), it2_ (it2) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            iterator (const iterator&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE
@@ -2448,6 +2513,11 @@ namespace boost { namespace numeric { namespace ublas {
             // BOOST_UBLAS_CHECK (r2_.start () <= data_.size2 () &&
             //                    r2_.start () + r2_.size () <= data_.size2 (), bad_index ());
         }
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+        BOOST_UBLAS_INLINE
+        matrix_range (const matrix_range&) = default;
+#endif
 
         // Accessors
         BOOST_UBLAS_INLINE
@@ -2682,6 +2752,11 @@ namespace boost { namespace numeric { namespace ublas {
             const_iterator1 (const iterator1 &it):
                 container_const_reference<self_type> (it ()), it_ (it.it_) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator1 (const const_iterator1&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             const_iterator1 &operator ++ () {
@@ -2853,6 +2928,11 @@ namespace boost { namespace numeric { namespace ublas {
             iterator1 (self_type &mr, const subiterator1_type &it):
                 container_reference<self_type> (mr), it_ (it) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            iterator1 (const iterator1&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             iterator1 &operator ++ () {
@@ -2992,6 +3072,11 @@ namespace boost { namespace numeric { namespace ublas {
             BOOST_UBLAS_INLINE
             const_iterator2 (const iterator2 &it):
                 container_const_reference<self_type> (it ()), it_ (it.it_) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator2 (const const_iterator2&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE
@@ -3163,6 +3248,11 @@ namespace boost { namespace numeric { namespace ublas {
             BOOST_UBLAS_INLINE
             iterator2 (self_type &mr, const subiterator2_type &it):
                 container_reference<self_type> (mr), it_ (it) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            iterator2 (const iterator2&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE
@@ -3441,6 +3531,11 @@ namespace boost { namespace numeric { namespace ublas {
             //                    s2_.start () + s2_.stride () * (s2_.size () - (s2_.size () > 0)) <= data_.size2 (), bad_index ());
         }
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+        BOOST_UBLAS_INLINE
+        matrix_slice (const matrix_slice&) = default;
+#endif
+
         // Accessors
         BOOST_UBLAS_INLINE
         size_type start1 () const {
@@ -3680,6 +3775,11 @@ namespace boost { namespace numeric { namespace ublas {
             const_iterator1 (const iterator1 &it):
                 container_const_reference<self_type> (it ()), it1_ (it.it1_), it2_ (it.it2_) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator1 (const const_iterator1&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             const_iterator1 &operator ++ () {
@@ -3855,6 +3955,11 @@ namespace boost { namespace numeric { namespace ublas {
             iterator1 (self_type &ms, const subiterator1_type &it1, const subiterator2_type &it2):
                 container_reference<self_type> (ms), it1_ (it1), it2_ (it2) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            iterator1 (const iterator1&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             iterator1 &operator ++ () {
@@ -3998,6 +4103,11 @@ namespace boost { namespace numeric { namespace ublas {
             BOOST_UBLAS_INLINE
             const_iterator2 (const iterator2 &it):
                 container_const_reference<self_type> (it ()), it1_ (it.it1_), it2_ (it.it2_) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator2 (const const_iterator2&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE
@@ -4173,6 +4283,11 @@ namespace boost { namespace numeric { namespace ublas {
             BOOST_UBLAS_INLINE
             iterator2 (self_type &ms, const subiterator1_type &it1, const subiterator2_type &it2):
                 container_reference<self_type> (ms), it1_ (it1), it2_ (it2) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            iterator2 (const iterator2&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE
@@ -4720,6 +4835,11 @@ namespace boost { namespace numeric { namespace ublas {
             const_iterator1 (const iterator1 &it):
                 container_const_reference<self_type> (it ()), it1_ (it.it1_), it2_ (it.it2_) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator1 (const const_iterator1&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             const_iterator1 &operator ++ () {
@@ -4895,6 +5015,11 @@ namespace boost { namespace numeric { namespace ublas {
             iterator1 (self_type &mi, const subiterator1_type &it1, const subiterator2_type &it2):
                 container_reference<self_type> (mi), it1_ (it1), it2_ (it2) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            iterator1 (const iterator1&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             iterator1 &operator ++ () {
@@ -5038,6 +5163,11 @@ namespace boost { namespace numeric { namespace ublas {
             BOOST_UBLAS_INLINE
             const_iterator2 (const iterator2 &it):
                 container_const_reference<self_type> (it ()), it1_ (it.it1_), it2_ (it.it2_) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator2 (const const_iterator2&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE
@@ -5213,6 +5343,11 @@ namespace boost { namespace numeric { namespace ublas {
             BOOST_UBLAS_INLINE
             iterator2 (self_type &mi, const subiterator1_type &it1, const subiterator2_type &it2):
                 container_reference<self_type> (mi), it1_ (it1), it2_ (it2) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            iterator2 (const iterator2&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE

--- a/include/boost/numeric/ublas/matrix_sparse.hpp
+++ b/include/boost/numeric/ublas/matrix_sparse.hpp
@@ -699,6 +699,11 @@ namespace boost { namespace numeric { namespace ublas {
             const_iterator1 (const iterator1 &it):
                 container_const_reference<self_type> (it ()), rank_ (it.rank_), i_ (it.i_), j_ (it.j_), it_ (it.it_) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator1 (const const_iterator1&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             const_iterator1 &operator ++ () {
@@ -881,6 +886,11 @@ namespace boost { namespace numeric { namespace ublas {
             iterator1 (self_type &m, int rank, size_type i, size_type j, const subiterator_type &it):
                 container_reference<self_type> (m), rank_ (rank), i_ (i), j_ (j), it_ (it) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            iterator1 (const iterator1&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             iterator1 &operator ++ () {
@@ -1031,6 +1041,11 @@ namespace boost { namespace numeric { namespace ublas {
             BOOST_UBLAS_INLINE
             const_iterator2 (const iterator2 &it):
                 container_const_reference<self_type> (it ()), rank_ (it.rank_), i_ (it.i_), j_ (it.j_), it_ (it.it_) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator2 (const const_iterator2&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE
@@ -1213,6 +1228,11 @@ namespace boost { namespace numeric { namespace ublas {
             BOOST_UBLAS_INLINE
             iterator2 (self_type &m, int rank, size_type i, size_type j, const subiterator_type &it):
                 container_reference<self_type> (m), rank_ (rank), i_ (i), j_ (j), it_ (it) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            iterator2 (const iterator2&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE
@@ -1956,6 +1976,11 @@ namespace boost { namespace numeric { namespace ublas {
             const_iterator1 (const iterator1 &it):
                 container_const_reference<self_type> (it ()), rank_ (it.rank_), i_ (it.i_), j_ (it.j_), itv_ (it.itv_), it_ (it.it_) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator1 (const const_iterator1&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             const_iterator1 &operator ++ () {
@@ -2167,6 +2192,11 @@ namespace boost { namespace numeric { namespace ublas {
             iterator1 (self_type &m, int rank, size_type i, size_type j, const vector_subiterator_type &itv, const subiterator_type &it):
                 container_reference<self_type> (m), rank_ (rank), i_ (i), j_ (j), itv_ (itv), it_ (it) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            iterator1 (const iterator1&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             iterator1 &operator ++ () {
@@ -2346,6 +2376,11 @@ namespace boost { namespace numeric { namespace ublas {
             BOOST_UBLAS_INLINE
             const_iterator2 (const iterator2 &it):
                 container_const_reference<self_type> (it ()), rank_ (it.rank_), i_ (it.i_), j_ (it.j_), itv_ (it.itv_), it_ (it.it_) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator2 (const const_iterator2&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE
@@ -2557,6 +2592,11 @@ namespace boost { namespace numeric { namespace ublas {
             BOOST_UBLAS_INLINE
             iterator2 (self_type &m, int rank, size_type i, size_type j, const vector_subiterator_type &itv, const subiterator_type &it):
                 container_reference<self_type> (m), rank_ (rank), i_ (i), j_ (j), itv_ (itv), it_ (it) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            iterator2 (const iterator2&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE
@@ -3483,6 +3523,11 @@ namespace boost { namespace numeric { namespace ublas {
             const_iterator1 (const iterator1 &it):
                 container_const_reference<self_type> (it ()), rank_ (it.rank_), i_ (it.i_), j_ (it.j_), itv_ (it.itv_), it_ (it.it_) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator1 (const const_iterator1&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             const_iterator1 &operator ++ () {
@@ -3671,6 +3716,11 @@ namespace boost { namespace numeric { namespace ublas {
             iterator1 (self_type &m, int rank, size_type i, size_type j, const vector_subiterator_type &itv, const subiterator_type &it):
                 container_reference<self_type> (m), rank_ (rank), i_ (i), j_ (j), itv_ (itv), it_ (it) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            iterator1 (const iterator1&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             iterator1 &operator ++ () {
@@ -3827,6 +3877,11 @@ namespace boost { namespace numeric { namespace ublas {
             BOOST_UBLAS_INLINE
             const_iterator2 (const iterator2 &it):
                 container_const_reference<self_type> (it ()), rank_ (it.rank_), i_ (it.i_), j_ (it.j_), itv_ (it.itv_), it_ (it.it_) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator2 (const const_iterator2&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE
@@ -4015,6 +4070,11 @@ namespace boost { namespace numeric { namespace ublas {
             BOOST_UBLAS_INLINE
             iterator2 (self_type &m, int rank, size_type i, size_type j, const vector_subiterator_type &itv, const subiterator_type &it):
                 container_reference<self_type> (m), rank_ (rank), i_ (i), j_ (j), itv_ (itv), it_ (it) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            iterator2(const iterator2&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE
@@ -4987,6 +5047,11 @@ namespace boost { namespace numeric { namespace ublas {
             const_iterator1 (const iterator1 &it):
                 container_const_reference<self_type> (it ()), rank_ (it.rank_), i_ (it.i_), j_ (it.j_), itv_ (it.itv_), it_ (it.it_) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator1 (const const_iterator1&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             const_iterator1 &operator ++ () {
@@ -5175,6 +5240,11 @@ namespace boost { namespace numeric { namespace ublas {
             iterator1 (self_type &m, int rank, size_type i, size_type j, const vector_subiterator_type &itv, const subiterator_type &it):
                 container_reference<self_type> (m), rank_ (rank), i_ (i), j_ (j), itv_ (itv), it_ (it) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            iterator1 (const iterator1&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             iterator1 &operator ++ () {
@@ -5331,6 +5401,11 @@ namespace boost { namespace numeric { namespace ublas {
             BOOST_UBLAS_INLINE
             const_iterator2 (const iterator2 &it):
                 container_const_reference<self_type> (it ()), rank_ (it.rank_), i_ (it.i_), j_ (it.j_), itv_ (it.itv_), it_ (it.it_) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator2 (const const_iterator2&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE
@@ -5519,6 +5594,11 @@ namespace boost { namespace numeric { namespace ublas {
             BOOST_UBLAS_INLINE
             iterator2 (self_type &m, int rank, size_type i, size_type j, const vector_subiterator_type &itv, const subiterator_type &it):
                 container_reference<self_type> (m), rank_ (rank), i_ (i), j_ (j), itv_ (itv), it_ (it) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            iterator2 (const iterator2&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE

--- a/include/boost/numeric/ublas/storage.hpp
+++ b/include/boost/numeric/ublas/storage.hpp
@@ -1100,6 +1100,11 @@ namespace boost { namespace numeric { namespace ublas {
             const_iterator (const basic_range &r, const const_subiterator_type &it):
                 container_const_reference<basic_range> (r), it_ (it) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator (const const_iterator&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             const_iterator &operator ++ () {
@@ -1336,6 +1341,11 @@ namespace boost { namespace numeric { namespace ublas {
             BOOST_UBLAS_INLINE
             const_iterator (const basic_slice &s, const const_subiterator_type &it):
                 container_const_reference<basic_slice> (s), it_ (it) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator (const const_iterator&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE
@@ -1617,6 +1627,11 @@ namespace boost { namespace numeric { namespace ublas {
             BOOST_UBLAS_INLINE
             const_iterator (const indirect_array &ia, const const_subiterator_type &it):
                 container_const_reference<indirect_array> (ia), it_ (it) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator (const const_iterator&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE

--- a/include/boost/numeric/ublas/symmetric.hpp
+++ b/include/boost/numeric/ublas/symmetric.hpp
@@ -326,6 +326,11 @@ namespace boost { namespace numeric { namespace ublas {
             const_iterator1 (const iterator1 &it):
                 container_const_reference<self_type> (it ()), it1_ (it.it1_), it2_ (it.it2_) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator1 (const const_iterator1&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             const_iterator1 &operator ++ () {
@@ -500,6 +505,11 @@ namespace boost { namespace numeric { namespace ublas {
             iterator1 (self_type &m, size_type it1, size_type it2):
                 container_reference<self_type> (m), it1_ (it1), it2_ (it2) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            iterator1 (const iterator1&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             iterator1 &operator ++ () {
@@ -643,6 +653,11 @@ namespace boost { namespace numeric { namespace ublas {
             BOOST_UBLAS_INLINE
             const_iterator2 (const iterator2 &it):
                 container_const_reference<self_type> (it ()), it1_ (it.it1_), it2_ (it.it2_) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator2 (const const_iterator2&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE
@@ -818,6 +833,11 @@ namespace boost { namespace numeric { namespace ublas {
             BOOST_UBLAS_INLINE
             iterator2 (self_type &m, size_type it1, size_type it2):
                 container_reference<self_type> (m), it1_ (it1), it2_ (it2) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            iterator2 (const iterator2&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE
@@ -1319,6 +1339,11 @@ namespace boost { namespace numeric { namespace ublas {
                                    (current_ == 1 && it2_ != it2_end_), internal_logic ());
             }
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator1 (const const_iterator1&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             const_iterator1 &operator ++ () {
@@ -1634,6 +1659,11 @@ namespace boost { namespace numeric { namespace ublas {
             iterator1 (self_type &m, const subiterator1_type &it1):
                 container_reference<self_type> (m), it1_ (it1) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            iterator1 (const iterator1&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             iterator1 &operator ++ () {
@@ -1801,6 +1831,11 @@ namespace boost { namespace numeric { namespace ublas {
                                    (current_ == 0 && it1_ != it1_end_) ||
                                    (current_ == 1 && it2_ != it2_end_), internal_logic ());
             }
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator2 (const const_iterator2&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE
@@ -2116,6 +2151,11 @@ namespace boost { namespace numeric { namespace ublas {
             BOOST_UBLAS_INLINE
             iterator2 (self_type &m, const subiterator2_type &it2):
                 container_reference<self_type> (m), it2_ (it2) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            iterator2 (const iterator2&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE

--- a/include/boost/numeric/ublas/triangular.hpp
+++ b/include/boost/numeric/ublas/triangular.hpp
@@ -368,6 +368,11 @@ namespace boost { namespace numeric { namespace ublas {
             const_iterator1 (const iterator1 &it):
                 container_const_reference<self_type> (it ()), it1_ (it.it1_), it2_ (it.it2_) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator1 (const const_iterator1&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             const_iterator1 &operator ++ () {
@@ -543,6 +548,11 @@ namespace boost { namespace numeric { namespace ublas {
             iterator1 (self_type &m, size_type it1, size_type it2):
                 container_reference<self_type> (m), it1_ (it1), it2_ (it2) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            iterator1 (const iterator1&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             iterator1 &operator ++ () {
@@ -686,6 +696,11 @@ namespace boost { namespace numeric { namespace ublas {
             BOOST_UBLAS_INLINE
             const_iterator2 (const iterator2 &it):
                 container_const_reference<self_type> (it ()), it1_ (it.it1_), it2_ (it.it2_) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator2 (const const_iterator2&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE
@@ -862,6 +877,11 @@ namespace boost { namespace numeric { namespace ublas {
             BOOST_UBLAS_INLINE
             iterator2 (self_type &m, size_type it1, size_type it2):
                 container_reference<self_type> (m), it1_ (it1), it2_ (it2) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            iterator2 (const iterator2&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE
@@ -1316,6 +1336,11 @@ namespace boost { namespace numeric { namespace ublas {
             const_iterator1 (const iterator1 &it):
                 container_const_reference<self_type> (it ()), it1_ (it.it1_) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator1 (const const_iterator1&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             const_iterator1 &operator ++ () {
@@ -1495,6 +1520,11 @@ namespace boost { namespace numeric { namespace ublas {
             iterator1 (self_type &m, const subiterator1_type &it1):
                 container_reference<self_type> (m), it1_ (it1) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            iterator1 (const iterator1&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             iterator1 &operator ++ () {
@@ -1641,6 +1671,11 @@ namespace boost { namespace numeric { namespace ublas {
             BOOST_UBLAS_INLINE
             const_iterator2 (const iterator2 &it):
                 container_const_reference<self_type> (it ()), it2_ (it.it2_) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator2 (const const_iterator2&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE
@@ -1819,6 +1854,11 @@ namespace boost { namespace numeric { namespace ublas {
             BOOST_UBLAS_INLINE
             iterator2 (self_type &m, const subiterator2_type &it2):
                 container_reference<self_type> (m), it2_ (it2) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            iterator2 (const iterator2&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE

--- a/include/boost/numeric/ublas/vector.hpp
+++ b/include/boost/numeric/ublas/vector.hpp
@@ -537,7 +537,12 @@ namespace boost { namespace numeric { namespace ublas {
 	        BOOST_UBLAS_INLINE
 	        const_iterator (const typename self_type::iterator &it):  // ISSUE vector:: stops VC8 using std::iterator here
 	            container_const_reference<self_type> (it ()), it_ (it.it_) {}
-	
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator (const const_iterator&) = default;
+#endif
+
 	    // ----------
 	        // Arithmetic
 	    // ----------
@@ -684,6 +689,11 @@ namespace boost { namespace numeric { namespace ublas {
 	         BOOST_UBLAS_INLINE
 	         iterator (self_type &v, const subiterator_type &it):
 	             container_reference<self_type> (v), it_ (it) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            iterator (const iterator&) = default;
+#endif
 
 	         // Arithmetic
 	         BOOST_UBLAS_INLINE
@@ -1309,6 +1319,11 @@ namespace boost { namespace numeric { namespace ublas {
             const_iterator (const typename self_type::iterator &it):  // ISSUE vector:: stops VC8 using std::iterator here
                 container_const_reference<self_type> (it ()), it_ (it.it_) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator (const const_iterator&) = default;
+#endif
+
         // ----------
             // Arithmetic
         // ----------
@@ -1455,6 +1470,11 @@ namespace boost { namespace numeric { namespace ublas {
              BOOST_UBLAS_INLINE
              iterator (self_type &v, const subiterator_type &it):
                  container_reference<self_type> (v), it_ (it) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            iterator (const iterator&) = default;
+#endif
 
              // Arithmetic
              BOOST_UBLAS_INLINE
@@ -1795,6 +1815,11 @@ namespace boost { namespace numeric { namespace ublas {
 	         const_iterator (const self_type &v):
 	             container_const_reference<self_type> (v) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator (const const_iterator&) = default;
+#endif
+
 	         // Arithmetic
 	         BOOST_UBLAS_INLINE
 	         const_iterator &operator ++ () {
@@ -2050,6 +2075,11 @@ namespace boost { namespace numeric { namespace ublas {
 	         const_iterator (const unit_vector &v, const const_subiterator_type &it):
 	             container_const_reference<unit_vector> (v), it_ (it) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator (const const_iterator&) = default;
+#endif
+
 	         // Arithmetic
 	         BOOST_UBLAS_INLINE
 	         const_iterator &operator ++ () {
@@ -2290,6 +2320,11 @@ namespace boost { namespace numeric { namespace ublas {
 	         BOOST_UBLAS_INLINE
 	         const_iterator (const scalar_vector &v, const const_subiterator_type &it):
 	             container_const_reference<scalar_vector> (v), it_ (it) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator (const const_iterator&) = default;
+#endif
 
 	         // Arithmetic
 	         BOOST_UBLAS_INLINE
@@ -2701,6 +2736,11 @@ namespace boost { namespace numeric { namespace ublas {
 	         const_iterator (const typename self_type::iterator &it):  // ISSUE self_type:: stops VC8 using std::iterator here
 	             container_const_reference<self_type> (it ()), it_ (it.it_) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator (const const_iterator&) = default;
+#endif
+
 	         // Arithmetic
 	         BOOST_UBLAS_INLINE
 	         const_iterator &operator ++ () {
@@ -2809,6 +2849,11 @@ namespace boost { namespace numeric { namespace ublas {
 	         BOOST_UBLAS_INLINE
 	         iterator (self_type &v, const subiterator_type &it):
 	             container_reference<self_type> (v), it_ (it) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            iterator (const iterator&) = default;
+#endif
 
 	         // Arithmetic
 	         BOOST_UBLAS_INLINE

--- a/include/boost/numeric/ublas/vector_expression.hpp
+++ b/include/boost/numeric/ublas/vector_expression.hpp
@@ -49,6 +49,11 @@ namespace boost { namespace numeric { namespace ublas {
         explicit vector_reference (referred_type &e):
             e_ (e) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+        BOOST_UBLAS_INLINE
+        vector_reference (const vector_reference&) = default;
+#endif
+
         // Accessors
         BOOST_UBLAS_INLINE
         size_type size () const {

--- a/include/boost/numeric/ublas/vector_proxy.hpp
+++ b/include/boost/numeric/ublas/vector_proxy.hpp
@@ -73,6 +73,11 @@ namespace boost { namespace numeric { namespace ublas {
             //                    r_.start () + r_.size () <= data_.size (), bad_index ());
         }
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+        BOOST_UBLAS_INLINE
+        vector_range (const vector_range&) = default;
+#endif
+
         // Accessors
         BOOST_UBLAS_INLINE
         size_type start () const {
@@ -280,6 +285,11 @@ namespace boost { namespace numeric { namespace ublas {
             BOOST_UBLAS_INLINE
             const_iterator (const typename self_type::iterator &it):  // ISSUE self_type:: stops VC8 using std::iterator here
                 container_const_reference<self_type> (it ()), it_ (it.it_) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator (const const_iterator&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE
@@ -645,6 +655,11 @@ namespace boost { namespace numeric { namespace ublas {
             //                    s_.start () + s_.stride () * (s_.size () - (s_.size () > 0)) <= data_.size (), bad_index ());
         }
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+        BOOST_UBLAS_INLINE
+        vector_slice (const vector_slice&) = default;
+#endif
+
         // Accessors
         BOOST_UBLAS_INLINE
         size_type start () const {
@@ -858,6 +873,11 @@ namespace boost { namespace numeric { namespace ublas {
             const_iterator (const typename self_type::iterator &it):  // ISSUE self_type:: stops VC8 using std::iterator here
                 container_const_reference<self_type> (it ()), it_ (it.it_) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator (const const_iterator&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             const_iterator &operator ++ () {
@@ -963,6 +983,11 @@ namespace boost { namespace numeric { namespace ublas {
             BOOST_UBLAS_INLINE
             iterator (self_type &vs, const subiterator_type &it):
                 container_reference<self_type> (vs), it_ (it) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            iterator (const iterator&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE
@@ -1419,6 +1444,11 @@ namespace boost { namespace numeric { namespace ublas {
             const_iterator (const typename self_type::iterator &it):  // ISSUE self_type:: stops VC8 using std::iterator here
                 container_const_reference<self_type> (it ()), it_ (it.it_) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator (const const_iterator&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             const_iterator &operator ++ () {
@@ -1524,6 +1554,11 @@ namespace boost { namespace numeric { namespace ublas {
             BOOST_UBLAS_INLINE
             iterator (self_type &vi, const subiterator_type &it):
                 container_reference<self_type> (vi), it_ (it) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            iterator (const iterator&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE

--- a/include/boost/numeric/ublas/vector_sparse.hpp
+++ b/include/boost/numeric/ublas/vector_sparse.hpp
@@ -623,6 +623,11 @@ namespace boost { namespace numeric { namespace ublas {
             const_iterator (const typename self_type::iterator &it):  // ISSUE self_type:: stops VC8 using std::iterator here
                 container_const_reference<self_type> (it ()), it_ (it.it_) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator (const const_iterator&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             const_iterator &operator ++ () {
@@ -1251,6 +1256,11 @@ namespace boost { namespace numeric { namespace ublas {
             const_iterator (const typename self_type::iterator &it):  // ISSUE self_type:: stops VC8 using std::iterator here
                 container_const_reference<self_type> (it ()), it_ (it.it_) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator (const const_iterator&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             const_iterator &operator ++ () {
@@ -1331,6 +1341,11 @@ namespace boost { namespace numeric { namespace ublas {
             BOOST_UBLAS_INLINE
             iterator (self_type &v, const subiterator_type &it):
                 container_reference<self_type> (v), it_ (it) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            iterator (const iterator&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE
@@ -2013,6 +2028,11 @@ namespace boost { namespace numeric { namespace ublas {
             const_iterator (const typename self_type::iterator &it):  // ISSUE self_type:: stops VC8 using std::iterator here
                 container_const_reference<self_type> (it ()), it_ (it.it_) {}
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            const_iterator (const const_iterator&) = default;
+#endif
+
             // Arithmetic
             BOOST_UBLAS_INLINE
             const_iterator &operator ++ () {
@@ -2093,6 +2113,11 @@ namespace boost { namespace numeric { namespace ublas {
             BOOST_UBLAS_INLINE
             iterator (self_type &v, const subiterator_type &it):
                 container_reference<self_type> (v), it_ (it) {}
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+            BOOST_UBLAS_INLINE
+            iterator (const iterator&) = default;
+#endif
 
             // Arithmetic
             BOOST_UBLAS_INLINE


### PR DESCRIPTION
All the implicit special member functions made explicit in this PR.
It fixes the compilation and test runs with `./b2 libs/numeric/ublas/test/ cxxstd=17 "cxxflags=-Werror=deprecated-copy" toolset=clang-13 -j4`