### PR TITLE
fix(lifetime): extending the lifetime of temporary objects

### DIFF
--- a/examples/tensor/simple_expressions.cpp
+++ b/examples/tensor/simple_expressions.cpp
@@ -65,6 +65,48 @@ int main()
     std::cout << "% --------------------------- " << std::endl << std::endl;
     std::cout << "F=" << F << ";" << std::endl << std::endl;
 
+    // Calling overloaded operators
+    // and mixing expression templates with prvalues, rvalues, and lvalues
+    {
+      auto G = tensor(shape{3,3}, 3.f);
+      auto E_9 = G + G + G;
+
+      // formatted output
+      std::cout << "% --------------------------- " << std::endl;
+      std::cout << "% --------------------------- " << std::endl << std::endl;
+      std::cout << "E(9)=" << tensor(E_9) << ";" << std::endl << std::endl;
+
+      auto E_6 = G + 3.f;
+
+      // formatted output
+      std::cout << "% --------------------------- " << std::endl;
+      std::cout << "% --------------------------- " << std::endl << std::endl;
+      std::cout << "E(6)=" << tensor(E_6) << ";" << std::endl << std::endl;
+
+      auto four = 4.f;
+      auto E_10 = E_6 + four;
+
+      // formatted output
+      std::cout << "% --------------------------- " << std::endl;
+      std::cout << "% --------------------------- " << std::endl << std::endl;
+      std::cout << "E(10)=" << tensor(E_10) << ";" << std::endl << std::endl;
+
+      auto E_23 = E_10 + E_10 + tensor(shape{3,3}, 3.f);
+
+      // formatted output
+      std::cout << "% --------------------------- " << std::endl;
+      std::cout << "% --------------------------- " << std::endl << std::endl;
+      std::cout << "E(23)=" << tensor(E_23) << ";" << std::endl << std::endl;
+
+      auto E_9_7 = tensor(shape{3,3}, 5.4f) + 4.3f;
+
+      // formatted output
+      std::cout << "% --------------------------- " << std::endl;
+      std::cout << "% --------------------------- " << std::endl << std::endl;
+      std::cout << "E(9.7)=" << tensor(E_9_7) << ";" << std::endl << std::endl;
+
+    }
+
   }  catch (const std::exception& e) {
     std::cerr << "Cought exception " << e.what();
     std::cerr << "in the main function of simple expression." << std::endl;

--- a/include/boost/numeric/ublas/tensor/expression.hpp
+++ b/include/boost/numeric/ublas/tensor/expression.hpp
@@ -1,5 +1,6 @@
 //
 //  Copyright (c) 2018-2019, Cem Bassoy, cem.bassoy@gmail.com
+// 	Copyright (c) 2022, Amit Singh, amitsingh19975@gmail.com
 //
 //  Distributed under the Boost Software License, Version 1.0. (See
 //  accompanying file LICENSE_1_0.txt or copy at
@@ -13,12 +14,67 @@
 #define BOOST_UBLAS_TENSOR_EXPRESSIONS_HPP
 
 #include <cstddef>
+#include <type_traits>
 #include <boost/numeric/ublas/expression_types.hpp>
 
 #include "tags.hpp"
 
 namespace boost::numeric::ublas::detail
 {
+
+template<class T, class E>
+struct tensor_expression;
+
+template<class T, class EL, class ER, class OP>
+struct binary_tensor_expression;
+
+template<class T, class E, class OP>
+struct unary_tensor_expression;
+
+template<typename E1, typename E2>
+concept same_exp = std::is_same_v< std::decay_t<E1>, std::decay_t<E2> >;
+
+template<typename T>
+struct does_exp_need_cast : std::false_type{};
+
+template<typename T>
+static constexpr bool does_exp_need_cast_v = does_exp_need_cast< std::decay_t<T> >::value;
+
+template<typename E, typename T>
+struct does_exp_need_cast< tensor_expression<T,E> > : std::true_type{};
+
+template<typename E, typename T>
+constexpr auto is_tensor_expression_impl(tensor_expression<T,E> const*) -> std::true_type;
+
+constexpr auto is_tensor_expression_impl(void const*) -> std::false_type;
+
+template<typename E>
+constexpr auto is_matrix_expression_impl(matrix_expression<E> const*) -> std::true_type;
+
+constexpr auto is_matrix_expression_impl(void const*) -> std::false_type;
+
+template<typename E>
+constexpr auto is_vector_expression_impl(vector_expression<E> const*) -> std::true_type;
+
+constexpr auto is_vector_expression_impl(void const*) -> std::false_type;
+
+template<typename E>
+concept TensorExpression = decltype(is_tensor_expression_impl(static_cast<std::decay_t<E> const*>(nullptr)))::value;
+
+// TODO: Remove this concept in the future when we have our own implementation of matrices.
+template<typename E>
+concept MatrixExpression = decltype(is_matrix_expression_impl(static_cast<std::decay_t<E> const*>(nullptr)))::value;
+
+// TODO: Remove this concept in the future when we have our own implementation of vectors.
+template<typename E>
+concept VectorExpression = decltype(is_vector_expression_impl(static_cast<std::decay_t<E> const*>(nullptr)))::value;
+
+template<typename Exp>
+using expression_operand_t = std::conditional_t<
+    !std::is_lvalue_reference_v<Exp>,
+    std::decay_t<Exp>,
+    std::add_lvalue_reference_t< std::add_const_t< std::decay_t<Exp> > >
+>;
 
 /** @\brief base class for tensor expressions
  *
@@ -30,7 +86,7 @@ namespace boost::numeric::ublas::detail
  **/
 template<class T, class E>
 struct tensor_expression
-    : public ublas_expression<E>
+    : public ublas_expression<E> // DISCUSS: Do we really need to do derive from ublas_expression?
 {
     //	static const unsigned complexity = 0;
     using expression_type = E;
@@ -40,11 +96,12 @@ struct tensor_expression
     inline
     constexpr auto const& operator()() const noexcept { return *static_cast<const expression_type*> (this); }
     
-    ~tensor_expression() = default;
+    constexpr tensor_expression(tensor_expression&&) noexcept = default;
+    constexpr tensor_expression& operator=(tensor_expression&&) noexcept = default;
+    constexpr ~tensor_expression() = default;
+
     tensor_expression(const tensor_expression&) = delete;
-    tensor_expression(tensor_expression&&) noexcept = delete;
     tensor_expression& operator=(const tensor_expression&) = delete;
-    tensor_expression& operator=(tensor_expression&&) noexcept = delete;
 
 
 protected :
@@ -58,71 +115,75 @@ struct binary_tensor_expression
 {
     using self_type = binary_tensor_expression<T,EL,ER,OP>;
     using tensor_type  = T;
-    using binary_operation = OP;
-    using expression_type_left  = EL;
-    using expression_type_right = ER;
+    using binary_operation = std::decay_t<OP>;
+    using expression_type_left  = expression_operand_t<EL>;
+    using expression_type_right = expression_operand_t<ER>;
     using derived_type =  tensor_expression <tensor_type,self_type>;
 
     using size_type = typename tensor_type::size_type;
 
-    explicit constexpr binary_tensor_expression(expression_type_left  const& l, expression_type_right const& r, binary_operation o) : el(l) , er(r) , op(std::move(o)) {}
-    constexpr binary_tensor_expression(binary_tensor_expression&& l) noexcept = delete;
-    constexpr binary_tensor_expression& operator=(binary_tensor_expression&& l) noexcept = delete;
-    ~binary_tensor_expression() = default;
-
     binary_tensor_expression() = delete;
+    
+    template<same_exp<EL> LeftExp, same_exp<ER> RightExp, typename OPType>
+    explicit constexpr binary_tensor_expression(LeftExp&& l, RightExp&& r, OPType&& o) 
+        : el(std::forward<LeftExp>(l)) 
+        , er(std::forward<RightExp>(r)) 
+        , op(std::forward<OPType>(o)) 
+    {}
+    constexpr binary_tensor_expression(binary_tensor_expression&& l) noexcept = default;
+    constexpr binary_tensor_expression& operator=(binary_tensor_expression&& l) noexcept = default;
+    constexpr ~binary_tensor_expression() = default;
+
     binary_tensor_expression(const binary_tensor_expression& l) = delete;
     binary_tensor_expression& operator=(binary_tensor_expression const& l) noexcept = delete;
 
 
+    [[nodiscard]] inline 
+    constexpr decltype(auto) operator()(size_type i) const 
+        requires (does_exp_need_cast_v<expression_type_left> && does_exp_need_cast_v<expression_type_right>)
+    { 
+        return op(el()(i), er()(i));
+    }
 
     [[nodiscard]] inline 
-    constexpr decltype(auto) operator()(size_type i) const { return op(el(i), er(i)); }
+    constexpr decltype(auto) operator()(size_type i) const 
+        requires (does_exp_need_cast_v<expression_type_left> && !does_exp_need_cast_v<expression_type_right>)
+    { 
+        return op(el()(i), er(i));
+    }
 
-    expression_type_left const& el;
-    expression_type_right const& er;
+    [[nodiscard]] inline 
+    constexpr decltype(auto) operator()(size_type i) const 
+        requires (!does_exp_need_cast_v<expression_type_left> && does_exp_need_cast_v<expression_type_right>)
+    { 
+        return op(el(i), er()(i));
+    }
+
+    [[nodiscard]] inline 
+    constexpr decltype(auto) operator()(size_type i) const { 
+        return op(el(i), er(i)); 
+    }
+
+    expression_type_left el;
+    expression_type_right er;
     binary_operation op;
 };
 
 /// @brief helper function to simply instantiation of lambda proxy class
-template<class T1, class T2, class EL, class ER, class OP>
+template<typename T, typename EL, typename ER, typename OP>
+    requires (
+        ( MatrixExpression<EL> || VectorExpression<EL> || TensorExpression<EL> ) &&
+        ( MatrixExpression<ER> || VectorExpression<ER> || TensorExpression<ER> ) 
+    )
 [[nodiscard]] inline
-constexpr auto make_binary_tensor_expression( tensor_expression<T1,EL> const& el, tensor_expression<T2,ER> const& er, OP op) noexcept
+constexpr auto make_binary_tensor_expression( EL&& el, ER&& er, OP&& op) noexcept
 {
-    static_assert( std::is_same_v< typename T1::value_type, typename T2::value_type>,
-        "boost::numeric::ublas::make_binary_tensor_expression(T1,T2) : LHS tensor and RHS tensor should have same value type"
+    return binary_tensor_expression<T,EL,ER,OP>( 
+        std::forward<EL>(el), 
+        std::forward<ER>(er), 
+        std::forward<OP>(op)
     );
-    return binary_tensor_expression<T1,EL,ER,OP>( el(), er(), op) ;
 }
-
-template<class T, class EL, class ER, class OP>
-[[nodiscard]] inline
-constexpr auto make_binary_tensor_expression( matrix_expression<EL> const& el, tensor_expression<T,ER> const& er, OP op) noexcept
-{
-    return binary_tensor_expression<T,EL,ER,OP>( el(), er(), op) ;
-}
-
-template<class T, class EL, class ER, class OP>
-[[nodiscard]] inline
-constexpr auto make_binary_tensor_expression( tensor_expression<T,EL> const& el, matrix_expression<ER> const& er, OP op) noexcept
-{
-    return binary_tensor_expression<T,EL,ER,OP>( el(), er(), op) ;
-}
-
-template<class T, class EL, class ER, class OP>
-[[nodiscard]] inline
-constexpr auto make_binary_tensor_expression( vector_expression<EL> const& el, tensor_expression<T,ER> const& er, OP op) noexcept
-{
-    return binary_tensor_expression<T,EL,ER,OP>( el(), er(), op) ;
-}
-
-template<class T, class EL, class ER, class OP>
-[[nodiscard]] inline
-constexpr auto make_binary_tensor_expression( tensor_expression<T,EL> const& el, vector_expression<ER> const& er, OP op) noexcept
-{
-    return binary_tensor_expression<T,EL,ER,OP>( el(), er(), op) ;
-}
-
 
 
 template<class T, class E, class OP>
@@ -132,50 +193,52 @@ struct unary_tensor_expression
 
     using self_type = unary_tensor_expression<T,E,OP>;
     using tensor_type  = T;
-    using expression_type = E;
-    using unary_operation = OP;
+    using expression_type = expression_operand_t<E>;
+    using unary_operation = std::decay_t<OP>;
     using derived_type = tensor_expression <T, unary_tensor_expression<T,E,OP>>;
 
     using size_type = typename tensor_type::size_type;
 
-    explicit constexpr unary_tensor_expression(expression_type const& ee, unary_operation o) : e(ee) , op(std::move(o)) {}
-    constexpr unary_tensor_expression(unary_tensor_expression&& l) noexcept = delete;
-    constexpr unary_tensor_expression& operator=(unary_tensor_expression&& l) noexcept = delete;
+    template<same_exp<E> Exp, typename OPType>
+    explicit constexpr unary_tensor_expression(Exp&& ee, OPType&& o) 
+        : e(std::forward<Exp>(ee))
+        , op(std::forward<OPType>(o)) 
+    {}
+    constexpr unary_tensor_expression(unary_tensor_expression&& l) noexcept = default;
+    constexpr unary_tensor_expression& operator=(unary_tensor_expression&& l) noexcept = default;
+    constexpr ~unary_tensor_expression() = default;
 
     constexpr unary_tensor_expression() = delete;
     unary_tensor_expression(unary_tensor_expression const& l) = delete;
     unary_tensor_expression& operator=(unary_tensor_expression const& l) noexcept = delete;
-    ~unary_tensor_expression() = default;
     
     [[nodiscard]] inline constexpr
-      decltype(auto) operator()(size_type i) const { return op(e(i)); }
+    decltype(auto) operator()(size_type i) const 
+        requires does_exp_need_cast_v<expression_type>
+    {
+        return op(e()(i));
+    }
 
-    E const& e;
-    OP op;
+    [[nodiscard]] inline constexpr
+    decltype(auto) operator()(size_type i) const { 
+        return op(e(i));
+    }
+
+    expression_type e;
+    unary_operation op;
 };
 
 // \brief helper function to simply instantiation of lambda proxy class
-template<class T, class E, class OP>
+template<typename T, typename E, typename OP>
+    requires ( MatrixExpression<E> || VectorExpression<E> || TensorExpression<E> )
 [[nodiscard]] inline
-constexpr auto make_unary_tensor_expression( tensor_expression<T,E> const& e, OP op) noexcept
+constexpr auto make_unary_tensor_expression( E&& e, OP&& op) noexcept
 {
-    return unary_tensor_expression<T,E,OP>( e() , op);
+    return unary_tensor_expression<T, E, OP>( 
+        std::forward<E>(e), 
+        std::forward<OP>(op)
+    );
 }
-
-template<class T, class E, class OP>
-[[nodiscard]] inline
-constexpr auto make_unary_tensor_expression( matrix_expression<E> const& e, OP op) noexcept
-{
-    return unary_tensor_expression<T,E,OP>( e() , op);
-}
-
-template<class T, class E, class OP>
-[[nodiscard]] inline
-constexpr auto make_unary_tensor_expression( vector_expression<E> const& e, OP op) noexcept
-{
-    return unary_tensor_expression<T,E,OP>( e() , op);
-}
-
 
 } // namespace boost::numeric::ublas::detail
 

--- a/include/boost/numeric/ublas/tensor/operators_arithmetic.hpp
+++ b/include/boost/numeric/ublas/tensor/operators_arithmetic.hpp
@@ -1,5 +1,6 @@
 //
 //  Copyright (c) 2018, Cem Bassoy, cem.bassoy@gmail.com
+// 	Copyright (c) 2022, Amit Singh, amitsingh19975@gmail.com
 //
 //  Distributed under the Boost Software License, Version 1.0. (See
 //  accompanying file LICENSE_1_0.txt or copy at
@@ -35,184 +36,172 @@ class matrix_expression;
 template<class E>
 class vector_expression;
 
+namespace detail{
+  
+  template<typename E>
+  struct real_expression_type {
+    using type = E;
+  };
+  
+  template<typename T, typename E>
+  struct real_expression_type< tensor_expression<T,E> > {
+    using type = T;
+  };
+  
+  template<typename T, typename EL, typename ER, typename OP>
+  struct real_expression_type< binary_tensor_expression<T, EL, ER, OP> > {
+    using type = T;
+  };
+  
+  template<typename T, typename E, typename OP>
+  struct real_expression_type< unary_tensor_expression<T, E, OP> > {
+    using type = T;
+  };
+
+  template<typename E>
+  using real_expression_type_t = typename real_expression_type< std::decay_t<E> >::type;
+
+} // namespace detail
+
+
 } // namespace boost::numeric::ublas
 
 
-template <class T, class L, class R>
+template <typename EL, typename ER>
+  requires ( 
+    (boost::numeric::ublas::detail::TensorExpression<EL>) &&
+    (boost::numeric::ublas::detail::VectorExpression<ER> || boost::numeric::ublas::detail::MatrixExpression<ER>)
+  )
 inline
-  constexpr auto operator*(
-    boost ::numeric ::ublas ::detail ::tensor_expression<T, L> const& lhs,
-    boost ::numeric ::ublas ::vector_expression<R> const& rhs) noexcept
+  constexpr auto operator*( EL&& lhs, ER&& rhs ) noexcept
 {
-  return boost ::numeric ::ublas ::detail ::make_binary_tensor_expression<T>(
-    lhs(), rhs(), std::multiplies<>{});
+    using tensor_type = boost::numeric::ublas::detail::real_expression_type_t<EL>;
+
+    return boost::numeric::ublas::detail::make_binary_tensor_expression<tensor_type>(
+      std::forward<EL>(lhs), std::forward<ER>(rhs), std::multiplies<>{}
+    );
 }
 
-template <class T, class L, class R>
+template <typename EL, typename ER>
+  requires ( 
+    (boost::numeric::ublas::detail::TensorExpression<EL>) &&
+    (boost::numeric::ublas::detail::VectorExpression<ER> || boost::numeric::ublas::detail::MatrixExpression<ER>)
+  )
 inline
-  constexpr auto operator+(
-    boost ::numeric ::ublas ::detail ::tensor_expression<T, L> const& lhs,
-    boost ::numeric ::ublas ::vector_expression<R> const& rhs) noexcept
+  constexpr auto operator+( EL&& lhs, ER&& rhs ) noexcept
 {
-  return boost ::numeric ::ublas ::detail ::make_binary_tensor_expression<T>(
-    lhs(), rhs(), std::plus<>{});
+    using tensor_type = boost::numeric::ublas::detail::real_expression_type_t<EL>;
+
+    return boost::numeric::ublas::detail::make_binary_tensor_expression<tensor_type>(
+      std::forward<EL>(lhs), std::forward<ER>(rhs), std::plus<>{}
+    );
 }
 
-template <class T, class L, class R>
+template <typename EL, typename ER>
+  requires ( 
+    (boost::numeric::ublas::detail::TensorExpression<EL>) &&
+    (boost::numeric::ublas::detail::VectorExpression<ER> || boost::numeric::ublas::detail::MatrixExpression<ER>)
+  )
 inline
-  constexpr auto operator-(
-    boost ::numeric ::ublas ::detail ::tensor_expression<T, L> const& lhs,
-    boost ::numeric ::ublas ::vector_expression<R> const& rhs) noexcept
+  constexpr auto operator-( EL&& lhs, ER&& rhs ) noexcept
 {
-  return boost ::numeric ::ublas ::detail ::make_binary_tensor_expression<T>(
-    lhs(), rhs(), std::minus<>{});
+    using tensor_type = boost::numeric::ublas::detail::real_expression_type_t<EL>;
+
+    return boost::numeric::ublas::detail::make_binary_tensor_expression<tensor_type>(
+      std::forward<EL>(lhs), std::forward<ER>(rhs), std::minus<>{}
+    );
 }
 
-template <class T, class L, class R>
+template <typename EL, typename ER>
+  requires ( 
+    (boost::numeric::ublas::detail::TensorExpression<EL>) &&
+    (boost::numeric::ublas::detail::VectorExpression<ER> || boost::numeric::ublas::detail::MatrixExpression<ER>)
+  )
 inline
-  constexpr auto operator/(
-    boost ::numeric ::ublas ::detail ::tensor_expression<T, L> const& lhs,
-    boost ::numeric ::ublas ::vector_expression<R> const& rhs) noexcept
+  constexpr auto operator/( EL&& lhs, ER&& rhs ) noexcept
 {
-  return boost ::numeric ::ublas ::detail ::make_binary_tensor_expression<T>(
-    lhs(), rhs(), std::divides<>{});
+    using tensor_type = boost::numeric::ublas::detail::real_expression_type_t<EL>;
+
+    return boost::numeric::ublas::detail::make_binary_tensor_expression<tensor_type>(
+      std::forward<EL>(lhs), std::forward<ER>(rhs), std::divides<>{}
+    );
 }
 
-
-template <class T, class L, class R>
+template <typename EL, typename ER>
+  requires ( 
+    (boost::numeric::ublas::detail::VectorExpression<EL> || boost::numeric::ublas::detail::MatrixExpression<EL>) &&
+    (boost::numeric::ublas::detail::TensorExpression<ER>)
+  )
 inline
-  constexpr auto operator*(
-    boost ::numeric ::ublas ::detail ::tensor_expression<T, L> const& lhs,
-    boost ::numeric ::ublas ::matrix_expression<R> const& rhs) noexcept
+  constexpr auto operator*( EL&& lhs, ER&& rhs ) noexcept
 {
-  return boost ::numeric ::ublas ::detail ::make_binary_tensor_expression<T>(
-    lhs(), rhs(), std::multiplies<>{});
+    using tensor_type = boost::numeric::ublas::detail::real_expression_type_t<ER>;
+
+    return boost::numeric::ublas::detail::make_binary_tensor_expression<tensor_type>(
+      std::forward<EL>(lhs), std::forward<ER>(rhs), std::multiplies<>{}
+    );
 }
 
-template <class T, class L, class R>
+template <typename EL, typename ER>
+  requires ( 
+    (boost::numeric::ublas::detail::VectorExpression<EL> || boost::numeric::ublas::detail::MatrixExpression<EL>) &&
+    (boost::numeric::ublas::detail::TensorExpression<ER>)
+  )
 inline
-  constexpr auto operator+(
-    boost ::numeric ::ublas ::detail ::tensor_expression<T, L> const& lhs,
-    boost ::numeric ::ublas ::matrix_expression<R> const& rhs) noexcept
+  constexpr auto operator+( EL&& lhs, ER&& rhs ) noexcept
 {
-  return boost ::numeric ::ublas ::detail ::make_binary_tensor_expression<T>(
-    lhs(), rhs(), std::plus<>{});
+    using tensor_type = boost::numeric::ublas::detail::real_expression_type_t<ER>;
+
+    return boost::numeric::ublas::detail::make_binary_tensor_expression<tensor_type>(
+      std::forward<EL>(lhs), std::forward<ER>(rhs), std::plus<>{}
+    );
 }
 
-template <class T, class L, class R>
+template <typename EL, typename ER>
+  requires ( 
+    (boost::numeric::ublas::detail::VectorExpression<EL> || boost::numeric::ublas::detail::MatrixExpression<EL>) &&
+    (boost::numeric::ublas::detail::TensorExpression<ER>)
+  )
 inline
-  constexpr auto operator-(
-    boost ::numeric ::ublas ::detail ::tensor_expression<T, L> const& lhs,
-    boost ::numeric ::ublas ::matrix_expression<R> const& rhs) noexcept
+  constexpr auto operator-( EL&& lhs, ER&& rhs ) noexcept
 {
-  return boost ::numeric ::ublas ::detail ::make_binary_tensor_expression<T>(
-    lhs(), rhs(), std::minus<>{});
+    using tensor_type = boost::numeric::ublas::detail::real_expression_type_t<ER>;
+
+    return boost::numeric::ublas::detail::make_binary_tensor_expression<tensor_type>(
+      std::forward<EL>(lhs), std::forward<ER>(rhs), std::minus<>{}
+    );
 }
 
-template <class T, class L, class R>
-inline
-  constexpr auto operator/(
-    boost ::numeric ::ublas ::detail ::tensor_expression<T, L> const& lhs,
-    boost ::numeric ::ublas ::matrix_expression<R> const& rhs) noexcept
+template <typename EL, typename ER>
+  requires ( 
+    (boost::numeric::ublas::detail::VectorExpression<EL> || boost::numeric::ublas::detail::MatrixExpression<EL>) &&
+    (boost::numeric::ublas::detail::TensorExpression<ER>)
+  )
+inline constexpr auto operator/( EL&& lhs, ER&& rhs ) noexcept
 {
-  return boost ::numeric ::ublas ::detail ::make_binary_tensor_expression<T>(
-    lhs(), rhs(), std::divides<>{});
+    using tensor_type = boost::numeric::ublas::detail::real_expression_type_t<ER>;
+
+    return boost::numeric::ublas::detail::make_binary_tensor_expression<tensor_type>(
+      std::forward<EL>(lhs), std::forward<ER>(rhs), std::divides<>{}
+    );
 }
 
-
-template <class T, class L, class R>
-inline
-  constexpr auto operator*(
-    boost ::numeric ::ublas ::vector_expression<L> const& lhs,
-    boost ::numeric ::ublas ::detail ::tensor_expression<T, R> const& rhs) noexcept
-{
-  return boost ::numeric ::ublas ::detail ::make_binary_tensor_expression<T>(
-    lhs(), rhs(), std::multiplies<>{});
-}
-
-template <class T, class L, class R>
-inline
-  constexpr auto operator+(
-    boost ::numeric ::ublas ::vector_expression<L> const& lhs,
-    boost ::numeric ::ublas ::detail ::tensor_expression<T, R> const& rhs) noexcept
-{
-  return boost ::numeric ::ublas ::detail ::make_binary_tensor_expression<T>(
-    lhs(), rhs(), std::plus<>{});
-}
-
-template <class T, class L, class R>
-inline
-  constexpr auto operator-(
-    boost ::numeric ::ublas ::vector_expression<L> const& lhs,
-    boost ::numeric ::ublas ::detail ::tensor_expression<T, R> const& rhs) noexcept
-{
-  return boost ::numeric ::ublas ::detail ::make_binary_tensor_expression<T>(
-    lhs(), rhs(), std::minus<>{});
-}
-
-template <class T, class L, class R>
-inline
-  constexpr auto operator/(
-    boost ::numeric ::ublas ::vector_expression<L> const& lhs,
-    boost ::numeric ::ublas ::detail ::tensor_expression<T, R> const& rhs) noexcept
-{
-  return boost ::numeric ::ublas ::detail ::make_binary_tensor_expression<T>(
-    lhs(), rhs(), std::divides<>{});
-}
-
-
-template <class T, class L, class R>
-inline
-  constexpr auto operator*(
-    boost ::numeric ::ublas ::matrix_expression<L> const& lhs,
-    boost ::numeric ::ublas ::detail ::tensor_expression<T, R> const& rhs) noexcept
-{
-  return boost ::numeric ::ublas ::detail ::make_binary_tensor_expression<T>(
-    lhs(), rhs(), std::multiplies<>{});
-}
-
-template <class T, class L, class R>
-inline
-  constexpr auto operator+(
-    boost ::numeric ::ublas ::matrix_expression<L> const& lhs,
-    boost ::numeric ::ublas ::detail ::tensor_expression<T, R> const& rhs) noexcept
-{
-  return boost ::numeric ::ublas ::detail ::make_binary_tensor_expression<T>(
-    lhs(), rhs(), std::plus<>{});
-}
-
-template <class T, class L, class R>
-inline
-  constexpr auto operator-(
-    boost ::numeric ::ublas ::matrix_expression<L> const& lhs,
-    boost ::numeric ::ublas ::detail ::tensor_expression<T, R> const& rhs) noexcept
-{
-  return boost ::numeric ::ublas ::detail ::make_binary_tensor_expression<T>(
-    lhs(), rhs(), std::minus<>{});
-}
-
-template <class T, class L, class R>
-inline
-  constexpr auto operator/(
-    boost ::numeric ::ublas ::matrix_expression<L> const& lhs,
-    boost ::numeric ::ublas ::detail ::tensor_expression<T, R> const& rhs) noexcept
-{
-  return boost ::numeric ::ublas ::detail ::make_binary_tensor_expression<T>(
-    lhs(), rhs(), std::divides<>{});
-}
-
-
-template<class T1, class T2, class L, class R>
-inline
-  constexpr auto operator+( boost::numeric::ublas::detail::tensor_expression<T1,L> const& lhs,
-    boost::numeric::ublas::detail::tensor_expression<T2,R> const& rhs) 
+template<typename EL, typename ER>
+  requires ( 
+    (boost::numeric::ublas::detail::TensorExpression<EL>) &&
+    (boost::numeric::ublas::detail::TensorExpression<ER>)
+  )
+inline constexpr auto operator+( EL&& lhs, ER&& rhs ) 
 {
 
-  static_assert( std::is_same_v< typename T1::value_type, typename T2::value_type>,
+  using ltensor_t = boost::numeric::ublas::detail::real_expression_type_t<EL>;
+  using rtensor_t = boost::numeric::ublas::detail::real_expression_type_t<ER>;
+
+  static_assert( std::is_same_v< typename ltensor_t::value_type, typename rtensor_t::value_type>,
                 "operator+() : LHS tensor and RHS tensor should have the same value type"
                 );
 
-  if constexpr( !std::is_same_v<T1,T2> ){
+  if constexpr( !std::is_same_v<ltensor_t,rtensor_t> ){
     auto const& e = boost::numeric::ublas::detail::retrieve_extents(rhs);
 
     if( !boost::numeric::ublas::detail::all_extents_equal(lhs,e) ){
@@ -220,173 +209,242 @@ inline
     }
   }
 
-  return boost::numeric::ublas::detail::make_binary_tensor_expression<T1> (lhs(), rhs(), [](auto const& l, auto const& r){ return l + r; });
+  return boost::numeric::ublas::detail::make_binary_tensor_expression<ltensor_t> (
+    std::forward<EL>(lhs), std::forward<ER>(rhs), [](auto const& l, auto const& r){ return l + r; }
+  );
 }
-template<class T1, class T2, class L, class R>
-inline
-  constexpr auto operator-( boost::numeric::ublas::detail::tensor_expression<T1,L> const& lhs,
-    boost::numeric::ublas::detail::tensor_expression<T2,R> const& rhs) 
+
+
+template<typename EL, typename ER>
+  requires ( 
+    (boost::numeric::ublas::detail::TensorExpression<EL>) &&
+    (boost::numeric::ublas::detail::TensorExpression<ER>)
+  )
+inline constexpr auto operator-( EL&& lhs, ER&& rhs ) 
 {
 
-  static_assert( std::is_same_v< typename T1::value_type, typename T2::value_type>,
+  using ltensor_t = boost::numeric::ublas::detail::real_expression_type_t<EL>;
+  using rtensor_t = boost::numeric::ublas::detail::real_expression_type_t<ER>;
+
+  static_assert( std::is_same_v< typename ltensor_t::value_type, typename rtensor_t::value_type>,
                 "operator-() : LHS tensor and RHS tensor should have the same value type"
                 );
 
-  if constexpr( !std::is_same_v<T1,T2> ){
-    auto e = boost::numeric::ublas::detail::retrieve_extents(rhs);
-
-    if( !boost::numeric::ublas::detail::all_extents_equal(lhs,e) ){
-      throw std::runtime_error("operator+() : LHS tensor and RHS tensor should have equal extents");
-    }
-  }
-
-  return boost::numeric::ublas::detail::make_binary_tensor_expression<T1> (lhs(), rhs(), [](auto const& l, auto const& r){ return l - r; });
-  //	return boost::numeric::ublas::detail::make_lambda<T>([&lhs,&rhs](std::size_t i){ return lhs(i) - rhs(i);});
-}
-template<class T1, class T2, class L, class R>
-inline
-  constexpr auto operator*( boost::numeric::ublas::detail::tensor_expression<T1,L> const& lhs,
-    boost::numeric::ublas::detail::tensor_expression<T2,R> const& rhs) 
-{
-
-  static_assert( std::is_same_v< typename T1::value_type, typename T2::value_type>,
-                "operator*() : LHS tensor and RHS tensor should have the same value type"
-                );
-
-  if constexpr( !std::is_same_v<T1,T2> ){
+  if constexpr( !std::is_same_v<ltensor_t,rtensor_t> ){
     auto const& e = boost::numeric::ublas::detail::retrieve_extents(rhs);
 
     if( !boost::numeric::ublas::detail::all_extents_equal(lhs,e) ){
-      throw std::runtime_error("operator+() : LHS tensor and RHS tensor should have equal extents");
+      throw std::runtime_error("operator-() : LHS tensor and RHS tensor should have equal extents");
     }
   }
 
-  return boost::numeric::ublas::detail::make_binary_tensor_expression<T1> (lhs(), rhs(), [](auto const& l, auto const& r){ return l * r; });
+  return boost::numeric::ublas::detail::make_binary_tensor_expression<ltensor_t> (
+    std::forward<EL>(lhs), std::forward<ER>(rhs), [](auto const& l, auto const& r){ return l - r; }
+  );
 }
-template<class T1, class T2, class L, class R>
-inline
-  constexpr auto operator/( boost::numeric::ublas::detail::tensor_expression<T1,L> const& lhs,
-    boost::numeric::ublas::detail::tensor_expression<T2,R> const& rhs) 
+
+template<typename EL, typename ER>
+  requires ( 
+    (boost::numeric::ublas::detail::TensorExpression<EL>) &&
+    (boost::numeric::ublas::detail::TensorExpression<ER>)
+  )
+inline constexpr auto operator*( EL&& lhs, ER&& rhs ) 
 {
 
-  static_assert( std::is_same_v< typename T1::value_type, typename T2::value_type>,
+  using ltensor_t = boost::numeric::ublas::detail::real_expression_type_t<EL>;
+  using rtensor_t = boost::numeric::ublas::detail::real_expression_type_t<ER>;
+
+  static_assert( std::is_same_v< typename ltensor_t::value_type, typename rtensor_t::value_type>,
+                "operator*() : LHS tensor and RHS tensor should have the same value type"
+                );
+
+  if constexpr( !std::is_same_v<ltensor_t,rtensor_t> ){
+    auto const& e = boost::numeric::ublas::detail::retrieve_extents(rhs);
+
+    if( !boost::numeric::ublas::detail::all_extents_equal(lhs,e) ){
+      throw std::runtime_error("operator*() : LHS tensor and RHS tensor should have equal extents");
+    }
+  }
+
+  return boost::numeric::ublas::detail::make_binary_tensor_expression<ltensor_t> (
+    std::forward<EL>(lhs), std::forward<ER>(rhs), [](auto const& l, auto const& r){ return l * r; }
+  );
+}
+
+template<typename EL, typename ER>
+  requires ( 
+    (boost::numeric::ublas::detail::TensorExpression<EL>) &&
+    (boost::numeric::ublas::detail::TensorExpression<ER>)
+  )
+inline constexpr auto operator/( EL&& lhs, ER&& rhs ) 
+{
+
+  using ltensor_t = boost::numeric::ublas::detail::real_expression_type_t<EL>;
+  using rtensor_t = boost::numeric::ublas::detail::real_expression_type_t<ER>;
+
+  static_assert( std::is_same_v< typename ltensor_t::value_type, typename rtensor_t::value_type>,
                 "operator/() : LHS tensor and RHS tensor should have the same value type"
                 );
 
-  if constexpr( !std::is_same_v<T1,T2> ){
-    auto e = boost::numeric::ublas::detail::retrieve_extents(rhs);
+  if constexpr( !std::is_same_v<ltensor_t,rtensor_t> ){
+    auto const& e = boost::numeric::ublas::detail::retrieve_extents(rhs);
 
     if( !boost::numeric::ublas::detail::all_extents_equal(lhs,e) ){
-      throw std::runtime_error("operator+() : LHS tensor and RHS tensor should have equal extents");
+      throw std::runtime_error("operator/() : LHS tensor and RHS tensor should have equal extents");
     }
   }
 
-  return boost::numeric::ublas::detail::make_binary_tensor_expression<T1> (lhs(), rhs(), std::divides<>{});
+  return boost::numeric::ublas::detail::make_binary_tensor_expression<ltensor_t> (
+    std::forward<EL>(lhs), std::forward<ER>(rhs), [](auto const& l, auto const& r){ return l / r; }
+  );
 }
 
 
 // Overloaded Arithmetic Operators with Scalars
-template<class T, class R>
-inline
-  constexpr auto operator+(typename boost::numeric::ublas::tensor_core<T>::const_reference lhs,
-    boost::numeric::ublas::detail::tensor_expression<boost::numeric::ublas::tensor_core<T>,R> const& rhs) noexcept
-{
-  using tensor_core_type = boost::numeric::ublas::tensor_core<T>;
-  return boost::numeric::ublas::detail::make_unary_tensor_expression<tensor_core_type> (rhs(), [lhs](auto const& r){ return lhs + r; });
-}
-template<class T, class R>
-inline
-  constexpr auto operator-(typename boost::numeric::ublas::tensor_core<T>::const_reference lhs,
-    boost::numeric::ublas::detail::tensor_expression<boost::numeric::ublas::tensor_core<T>,R> const& rhs) noexcept
-{
-  using tensor_core_type = boost::numeric::ublas::tensor_core<T>;
-  return boost::numeric::ublas::detail::make_unary_tensor_expression<tensor_core_type> (rhs(), [lhs](auto const& r){ return lhs - r; });
-}
-template<class T, class R>
-inline
-  constexpr auto operator*(typename boost::numeric::ublas::tensor_core<T>::const_reference lhs,
-    boost::numeric::ublas::detail::tensor_expression<boost::numeric::ublas::tensor_core<T>,R> const& rhs) noexcept
-{
-  using tensor_core_type = boost::numeric::ublas::tensor_core<T>;
-  return boost::numeric::ublas::detail::make_unary_tensor_expression<tensor_core_type> (rhs(), [lhs](auto const& r){ return lhs * r; });
-}
-template<class T, class R>
-inline
-  constexpr auto operator/(typename boost::numeric::ublas::tensor_core<T>::const_reference lhs,
-    boost::numeric::ublas::detail::tensor_expression<boost::numeric::ublas::tensor_core<T>,R> const& rhs) noexcept
-{
-  using tensor_core_type = boost::numeric::ublas::tensor_core<T>;
-  return boost::numeric::ublas::detail::make_unary_tensor_expression<tensor_core_type> (rhs(), [lhs](auto const& r){ return lhs / r; });
+template<typename ER>
+  requires (boost::numeric::ublas::detail::TensorExpression<ER>)
+inline constexpr auto operator+( 
+  typename boost::numeric::ublas::detail::real_expression_type_t<ER>::value_type lhs, 
+  ER&& rhs 
+) noexcept {
+  using tensor_type = boost::numeric::ublas::detail::real_expression_type_t<ER>;
+  
+  return boost::numeric::ublas::detail::make_unary_tensor_expression<tensor_type> (
+    std::forward<ER>(rhs),
+    [lhs](auto const& r){ return lhs + r; }
+  );
 }
 
+template<typename ER>
+  requires (boost::numeric::ublas::detail::TensorExpression<ER>)
+inline constexpr auto operator-( 
+  typename boost::numeric::ublas::detail::real_expression_type_t<ER>::value_type lhs, 
+  ER&& rhs
+) noexcept {
+  using tensor_type = boost::numeric::ublas::detail::real_expression_type_t<ER>;
 
-template<class T, class L>
-inline
-  constexpr auto operator+(boost::numeric::ublas::detail::tensor_expression<boost::numeric::ublas::tensor_core<T>,L> const& lhs,
-    typename boost::numeric::ublas::tensor_core<T>::const_reference rhs) noexcept
-{
-  using tensor_core_type = boost::numeric::ublas::tensor_core<T>;
-  return boost::numeric::ublas::detail::make_unary_tensor_expression<tensor_core_type> (lhs(), [rhs] (auto const& l) { return l + rhs; } );
-}
-template<class T, class L>
-inline
-  constexpr auto operator-(boost::numeric::ublas::detail::tensor_expression<boost::numeric::ublas::tensor_core<T>,L> const& lhs,
-    typename boost::numeric::ublas::tensor_core<T>::const_reference rhs) noexcept
-{
-  using tensor_core_type = boost::numeric::ublas::tensor_core<T>;
-  return boost::numeric::ublas::detail::make_unary_tensor_expression<tensor_core_type> (lhs(), [rhs] (auto const& l) { return l - rhs; } );
-}
-template<class T, class L>
-inline
-  constexpr auto operator*(boost::numeric::ublas::detail::tensor_expression<boost::numeric::ublas::tensor_core<T>,L> const& lhs,
-    typename boost::numeric::ublas::tensor_core<T>::const_reference rhs) noexcept
-{
-  using tensor_core_type = boost::numeric::ublas::tensor_core<T>;
-  return boost::numeric::ublas::detail::make_unary_tensor_expression<tensor_core_type> (lhs(), [rhs] (auto const& l) { return l * rhs; } );
-}
-template<class T, class L>
-inline
-  constexpr auto operator/(boost::numeric::ublas::detail::tensor_expression<boost::numeric::ublas::tensor_core<T>,L> const& lhs,
-    typename boost::numeric::ublas::tensor_core<T>::const_reference rhs) noexcept
-{
-  using tensor_core_type = boost::numeric::ublas::tensor_core<T>;
-  return boost::numeric::ublas::detail::make_unary_tensor_expression<tensor_core_type> (lhs(), [rhs] (auto const& l) { return l / rhs; } );
+  return boost::numeric::ublas::detail::make_unary_tensor_expression<tensor_type> (
+    std::forward<ER>(rhs),
+    [lhs](auto const& r){ return lhs - r; }
+  );
 }
 
+template<typename ER>
+  requires (boost::numeric::ublas::detail::TensorExpression<ER>)
+inline constexpr auto operator*( 
+  typename boost::numeric::ublas::detail::real_expression_type_t<ER>::value_type lhs, 
+  ER&& rhs
+) noexcept {
+  using tensor_type = boost::numeric::ublas::detail::real_expression_type_t<ER>;
 
+  return boost::numeric::ublas::detail::make_unary_tensor_expression<tensor_type> (
+    std::forward<ER>(rhs),
+    [lhs](auto const& r){ return lhs * r; }
+  );
+}
+
+template<typename ER>
+  requires (boost::numeric::ublas::detail::TensorExpression<ER>)
+inline constexpr auto operator/( 
+  typename boost::numeric::ublas::detail::real_expression_type_t<ER>::value_type lhs, 
+  ER&& rhs
+) noexcept {
+  using tensor_type = boost::numeric::ublas::detail::real_expression_type_t<ER>;
+
+  return boost::numeric::ublas::detail::make_unary_tensor_expression<tensor_type> (
+    std::forward<ER>(rhs),
+    [lhs](auto const& r){ return lhs / r; }
+  );
+}
+
+template<typename EL>
+  requires (boost::numeric::ublas::detail::TensorExpression<EL>)
+inline constexpr auto operator+( 
+  EL&& lhs, 
+  typename boost::numeric::ublas::detail::real_expression_type_t<EL>::value_type rhs 
+) noexcept {
+  using tensor_type = boost::numeric::ublas::detail::real_expression_type_t<EL>;
+  
+  return boost::numeric::ublas::detail::make_unary_tensor_expression<tensor_type> (
+    std::forward<EL>(lhs),
+    [rhs] (auto const& l) { return l + rhs; } 
+  );
+}
+
+template<typename EL>
+  requires (boost::numeric::ublas::detail::TensorExpression<EL>)
+inline constexpr auto operator-( 
+  EL&& lhs, 
+  typename boost::numeric::ublas::detail::real_expression_type_t<EL>::value_type rhs 
+) noexcept {
+  using tensor_type = boost::numeric::ublas::detail::real_expression_type_t<EL>;
+  
+  return boost::numeric::ublas::detail::make_unary_tensor_expression<tensor_type> (
+    std::forward<EL>(lhs),
+    [rhs] (auto const& l) { return l - rhs; } 
+  );
+}
+
+template<typename EL>
+  requires (boost::numeric::ublas::detail::TensorExpression<EL>)
+inline constexpr auto operator*( 
+  EL&& lhs, 
+  typename boost::numeric::ublas::detail::real_expression_type_t<EL>::value_type rhs 
+) noexcept {
+  using tensor_type = boost::numeric::ublas::detail::real_expression_type_t<EL>;
+  
+  return boost::numeric::ublas::detail::make_unary_tensor_expression<tensor_type> (
+    std::forward<EL>(lhs),
+    [rhs] (auto const& l) { return l * rhs; } 
+  );
+}
+
+template<typename EL>
+  requires (boost::numeric::ublas::detail::TensorExpression<EL>)
+inline constexpr auto operator/( 
+  EL&& lhs, 
+  typename boost::numeric::ublas::detail::real_expression_type_t<EL>::value_type rhs 
+) noexcept {
+  using tensor_type = boost::numeric::ublas::detail::real_expression_type_t<EL>;
+  
+  return boost::numeric::ublas::detail::make_unary_tensor_expression<tensor_type> (
+    std::forward<EL>(lhs),
+    [rhs] (auto const& l) { return l / rhs; } 
+  );
+}
 
 template<class T, class D>
-inline
-  constexpr auto& operator += (boost::numeric::ublas::tensor_core<T>& lhs,
-    const boost::numeric::ublas::detail::tensor_expression<boost::numeric::ublas::tensor_core<T>,D> &expr)
-{
+inline constexpr auto& operator += (
+  boost::numeric::ublas::tensor_core<T>& lhs,
+  boost::numeric::ublas::detail::tensor_expression<boost::numeric::ublas::tensor_core<T>,D> const& expr
+){
   boost::numeric::ublas::detail::eval(lhs, expr(), [](auto& l, auto const& r) { l+=r; } );
   return lhs;
 }
 
 template<class T, class D>
-inline
-  constexpr auto& operator -= (boost::numeric::ublas::tensor_core<T>& lhs,
-    const boost::numeric::ublas::detail::tensor_expression<boost::numeric::ublas::tensor_core<T>,D> &expr)
-{
+inline constexpr auto& operator -= (
+  boost::numeric::ublas::tensor_core<T>& lhs,
+  const boost::numeric::ublas::detail::tensor_expression<boost::numeric::ublas::tensor_core<T>,D> &expr
+){
   boost::numeric::ublas::detail::eval(lhs, expr(), [](auto& l, auto const& r) { l-=r; } );
   return lhs;
 }
 
 template<class T, class D>
-inline
-  constexpr auto& operator *= (boost::numeric::ublas::tensor_core<T>& lhs,
-    const boost::numeric::ublas::detail::tensor_expression<boost::numeric::ublas::tensor_core<T>,D> &expr)
-{
+inline constexpr auto& operator *= (
+  boost::numeric::ublas::tensor_core<T>& lhs,
+  const boost::numeric::ublas::detail::tensor_expression<boost::numeric::ublas::tensor_core<T>,D> &expr
+){
   boost::numeric::ublas::detail::eval(lhs, expr(), [](auto& l, auto const& r) { l*=r; } );
   return lhs;
 }
 
 template<class T, class D>
-inline
-  constexpr auto& operator /= (boost::numeric::ublas::tensor_core<T>& lhs,
-    const boost::numeric::ublas::detail::tensor_expression<boost::numeric::ublas::tensor_core<T>,D> &expr)
-{
+inline constexpr auto& operator /= (
+  boost::numeric::ublas::tensor_core<T>& lhs,
+  const boost::numeric::ublas::detail::tensor_expression<boost::numeric::ublas::tensor_core<T>,D> &expr
+){
   boost::numeric::ublas::detail::eval(lhs, expr(), [](auto& l, auto const& r) { l/=r; } );
   return lhs;
 }
@@ -395,55 +453,56 @@ inline
 
 
 template<class TensorEngine>
-inline
-  constexpr auto& operator += (boost::numeric::ublas::tensor_core<TensorEngine>& lhs,
-    typename boost::numeric::ublas::tensor_core<TensorEngine>::const_reference r)
-{
+inline constexpr auto& operator += (
+    boost::numeric::ublas::tensor_core<TensorEngine>& lhs,
+    typename boost::numeric::ublas::tensor_core<TensorEngine>::value_type r
+){
   boost::numeric::ublas::detail::eval(lhs, [r](auto& l) { l+=r; } );
   return lhs;
 }
 
-template<typename TensorEngine>
-inline
-  constexpr auto& operator -= (boost::numeric::ublas::tensor_core<TensorEngine>& lhs,
-    typename boost::numeric::ublas::tensor_core<TensorEngine>::const_reference r)
-{
+template<class TensorEngine>
+inline constexpr auto& operator -= (
+  boost::numeric::ublas::tensor_core<TensorEngine>& lhs,
+  typename boost::numeric::ublas::tensor_core<TensorEngine>::value_type r
+){
   boost::numeric::ublas::detail::eval(lhs, [r](auto& l) { l-=r; } );
   return lhs;
 }
 
-template<typename TensorEngine>
-inline
-  constexpr auto& operator *= (boost::numeric::ublas::tensor_core<TensorEngine>& lhs,
-    typename boost::numeric::ublas::tensor_core<TensorEngine>::const_reference r)
-{
+template<class TensorEngine>
+inline constexpr auto& operator *= (
+  boost::numeric::ublas::tensor_core<TensorEngine>& lhs,
+  typename boost::numeric::ublas::tensor_core<TensorEngine>::value_type r
+){
   boost::numeric::ublas::detail::eval(lhs, [r](auto& l) { l*=r; } );
   return lhs;
 }
 
-template<typename TensorEngine>
-constexpr auto& operator /= (boost::numeric::ublas::tensor_core<TensorEngine>& lhs, 
-    typename boost::numeric::ublas::tensor_core<TensorEngine>::const_reference r)
-{
+template<class TensorEngine>
+inline constexpr auto& operator /= (
+  boost::numeric::ublas::tensor_core<TensorEngine>& lhs,
+  typename boost::numeric::ublas::tensor_core<TensorEngine>::value_type r
+){
   boost::numeric::ublas::detail::eval(lhs, [r](auto& l) { l/=r; } );
-    return lhs;
-}
-
-
-
-
-
-
-template<class T, class D>
-inline constexpr
-  auto const& operator +(const boost::numeric::ublas::detail::tensor_expression<T,D>& lhs) noexcept{
   return lhs;
 }
 
+
+
 template<class T, class D>
 inline constexpr
-  auto operator -(boost::numeric::ublas::detail::tensor_expression<T,D> const& lhs) {
-  return boost::numeric::ublas::detail::make_unary_tensor_expression<T> (lhs(), std::negate<>{} );
+  auto const& operator +(boost::numeric::ublas::detail::tensor_expression<T,D> const& lhs) noexcept{
+  return lhs;
+}
+
+template<typename E>
+  requires boost::numeric::ublas::detail::TensorExpression<E>
+inline constexpr auto operator -(E&& e) {
+  using tensor_type = boost::numeric::ublas::detail::real_expression_type_t<E>;
+  return boost::numeric::ublas::detail::make_unary_tensor_expression<tensor_type> (
+    std::forward<E>(e), std::negate<>{} 
+  );
 }
 
 


### PR DESCRIPTION
The current implementation does not take into account the prvalue that
creates an issue while storing it. The prvalue is destroyed after the
end of its scope, and if you try to access it, you are entering into
the undefined land of C++.

To solve this issue, we employ the trait `std::is_lvalue_reference` to
determine if need to extend the lifetime or not. If an extension is needed,
we store the value with the help of universal forwarding. Otherwise, we
extend the lifetime using `const &`.

Resolves #125, resolves #118