### PR TITLE
chore: bump macos runner version

### DIFF
--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -16,8 +16,8 @@ on:
       - 'doc/**'
 jobs:
   build:
-    name: "MacOS 10.15 clang -std=c++${{matrix.cxxstd}}"
-    runs-on: macos-10.15
+    name: "MacOS 11 clang -std=c++${{matrix.cxxstd}}"
+    runs-on: macos-11
     strategy:
       fail-fast: true
       matrix:


### PR DESCRIPTION
GitHub Action is sunsetting the macOS 10.15 Actions runner. It will stop working intermittently until being completely removed by 2022-8-30: https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22