### PR TITLE
Avoid references to root build project.

### DIFF
--- a/examples/tensor/Jamfile
+++ b/examples/tensor/Jamfile
@@ -6,7 +6,7 @@
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-import ../../../../config/checks/config : requires ;
+import config : requires ;
  
 # Project settings
 project boost-ublas-tensor-example

--- a/test/tensor/Jamfile
+++ b/test/tensor/Jamfile
@@ -11,7 +11,7 @@
 #  Google and Fraunhofer IOSB, Ettlingen, Germany
 #
 
-import ../../../../config/checks/config : requires ;
+import config : requires ;
 
 project boost/ublas/test/tensor
     : requirements


### PR DESCRIPTION
In order to make the library transportable, specifically so we can support modular Boost distribution, we need to avoid encoding absolute paths to the monolithic Boost structure. This changes the config check references to be symbolic, as they are already configured to be found automatically.
