### PR TITLE
fix(iterator): remove deprecated inheritance from std::iterator (#97)

### DIFF
--- a/include/boost/numeric/ublas/detail/iterator.hpp
+++ b/include/boost/numeric/ublas/detail/iterator.hpp
@@ -107,8 +107,12 @@ namespace boost { namespace numeric { namespace ublas {
    * via the post increment operator.
    */
     template<class IC, class I, class T>
-    struct forward_iterator_base:
-        public std::iterator<IC, T> {
+    struct forward_iterator_base {
+        typedef IC iterator_category;
+        typedef T value_type;
+        typedef std::ptrdiff_t difference_type;
+        typedef T* pointer;
+        typedef T& reference;
         typedef I derived_iterator_type;
         typedef T derived_value_type;
 
@@ -145,8 +149,12 @@ namespace boost { namespace numeric { namespace ublas {
    * via the post increment and post decrement operator.
    */
     template<class IC, class I, class T>
-    struct bidirectional_iterator_base:
-        public std::iterator<IC, T> {
+    struct bidirectional_iterator_base {
+        typedef IC iterator_category;
+        typedef T value_type;
+        typedef std::ptrdiff_t difference_type;
+        typedef T* pointer;
+        typedef T& reference;
         typedef I derived_iterator_type;
         typedef T derived_value_type;
 
@@ -200,8 +208,12 @@ namespace boost { namespace numeric { namespace ublas {
    */
     template<class IC, class I, class T, class D = std::ptrdiff_t>
     // ISSUE the default for D seems rather dangerous as it can easily be (silently) incorrect
-    struct random_access_iterator_base:
-        public std::iterator<IC, T> {
+    struct random_access_iterator_base {
+        typedef IC iterator_category;
+        typedef T value_type;
+        typedef D difference_type;
+        typedef T* pointer;
+        typedef T& reference;
         typedef I derived_iterator_type;
         typedef T derived_value_type;
         typedef D derived_difference_type;


### PR DESCRIPTION
`std::iterator` was deprecated in C++17 and removed in C++20. I replaced the inheritance with the 5 equivalent typedefs, even though they're not all used by ublas, for compatibility in case clients depend on them.

Fixes issue https://github.com/boostorg/ublas/issues/176